### PR TITLE
FFWEB-1332: Data Export - Fix for category paths

### DIFF
--- a/src/Model/Config/Communication.php
+++ b/src/Model/Config/Communication.php
@@ -43,12 +43,17 @@ class Communication implements ParametersSourceInterface
 
     private function getCategoryPath(Category $category, string $param = 'CategoryPath'): string
     {
+        $categories = [$category];
+        while ($parent = $category->getParentCategory()) {
+            $categories[] = $parent;
+            $category = $parent;
+        }
+
         $path  = 'ROOT';
         $value = ['navigation=true'];
-        while ($category) {
-            $value[]  = sprintf("filter{$param}%s=%s", $path, urlencode($category->getTitle()));
+        foreach (array_reverse($categories) as $category) {
+            $value[] = sprintf("filter{$param}%s=%s", $path, urlencode($category->getTitle()));
             $path     .= urlencode('/' . $category->getTitle());
-            $category = $category->getParentCategory();
         }
         return implode(',', $value);
     }

--- a/src/Model/Config/Communication.php
+++ b/src/Model/Config/Communication.php
@@ -46,14 +46,14 @@ class Communication implements ParametersSourceInterface
         $categories = [$category];
         while ($parent = $category->getParentCategory()) {
             $categories[] = $parent;
-            $category = $parent;
+            $category     = $parent;
         }
 
         $path  = 'ROOT';
         $value = ['navigation=true'];
         foreach (array_reverse($categories) as $category) {
             $value[] = sprintf("filter{$param}%s=%s", $path, urlencode($category->getTitle()));
-            $path     .= urlencode('/' . $category->getTitle());
+            $path    .= urlencode('/' . $category->getTitle());
         }
         return implode(',', $value);
     }

--- a/src/Model/Export/Entity/Article/Fields/CategoryPath.php
+++ b/src/Model/Export/Entity/Article/Fields/CategoryPath.php
@@ -47,7 +47,7 @@ class CategoryPath implements FieldModifierInterface
         return implode('|', $paths);
     }
 
-    private function getCategoryById(string $id = ''): Category
+    private function getCategoryById(string $id): Category
     {
         $category = oxNew(Category::class);
         if (!$category->load($id)) {

--- a/src/Model/Export/Entity/Article/Fields/CategoryPath.php
+++ b/src/Model/Export/Entity/Article/Fields/CategoryPath.php
@@ -39,7 +39,7 @@ class CategoryPath implements FieldModifierInterface
 
                 if (!empty($path)) {
                     $this->cachedPaths[$pathId] = implode('/', array_reverse($path));
-                    $paths[] = $this->cachedPaths[$pathId];
+                    $paths[]                    = $this->cachedPaths[$pathId];
                 }
             }
         }

--- a/src/Model/Export/Entity/Article/Fields/CategoryPath.php
+++ b/src/Model/Export/Entity/Article/Fields/CategoryPath.php
@@ -26,14 +26,17 @@ class CategoryPath implements FieldModifierInterface
 
         foreach (explode(',', $entity->getCategoryPath()) as $pathId) {
             if (isset($this->cachedPaths[$pathId])) {
-                $paths [] = $this->cachedPaths[$pathId];
+                $paths[] = $this->cachedPaths[$pathId];
             } else {
-                $category = $this->getCategoryById($pathId);
                 $path = [];
-                while ($category->oxcategories__oxparentid->value != 'oxrootid') {
-                    $path[] = $category->oxcategories__oxtitle->value;
-                    $category = $this->getCategoryById($category->oxcategories__oxparentid->value);
+                while ($category = $this->getCategoryById($pathId)) {
+                    $path[] = $category->getTitle();
+                    if (!$category->getParentCategory()) {
+                        break;
+                    }
+                    $pathId = $category->getParentCategory()->getId();
                 }
+
                 if (!empty($path)) {
                     $this->cachedPaths[$pathId] = implode('/', array_reverse($path));
                     $paths[] = $this->cachedPaths[$pathId];
@@ -44,7 +47,7 @@ class CategoryPath implements FieldModifierInterface
         return implode('|', $paths);
     }
 
-    private function getCategoryById(string $id): Category
+    private function getCategoryById(string $id = ''): Category
     {
         $category = oxNew(Category::class);
         if (!$category->load($id)) {


### PR DESCRIPTION
- Solves issue: 
Fixes for category paths
- Description: 
Category paths are exported without top parent category :
now: ```Kiteboards```
should be ```Kiteboarding\Kiteboards```
CategoryPaths filter is created in wrong order:
now: ```filterCategoryPathROOT%2FKiteboards=Kiteboarding&filterCategoryPathROOT=Kiteboards```
should be: ```filterCategoryPathROOT=Kiteboarding&filterCategoryPathROOT%2FKiteboarding=Kiteboards```
since in sample data Kiteboards is a child category of Kiteboarding

- Tested with Oxid EShop editions/versions: 
6.1.3
- Tested with PHP versions: 
7.0