### PR TITLE
autoload files in modules folder

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
   },
   "autoload": {
     "psr-4": {
-      "Omikron\\FactFinder\\Oxid\\": "src"
+      "Omikron\\FactFinder\\Oxid\\": "../../../source/modules/ff/ffwebcomponents"
     }
   },
   "extra": {


### PR DESCRIPTION
> In order to load module classes the module needs to register it’s namespace to the modules path
https://docs.oxid-esales.com/developer/en/6.0/modules/skeleton/composerjson/module_via_composer.html#module-autoload-20170926

Otherwise sometimes the files located in modules are loaded and sometime the files in vendor are loaded. OXID unfortunately copies your files.