### PR TITLE
Add missing root category

### DIFF
--- a/src/Model/Export/Entity/Article/Fields/CategoryPath.php
+++ b/src/Model/Export/Entity/Article/Fields/CategoryPath.php
@@ -34,6 +34,7 @@ class CategoryPath implements FieldModifierInterface
                     $path[] = $category->oxcategories__oxtitle->value;
                     $category = $this->getCategoryById($category->oxcategories__oxparentid->value);
                 }
+                $path[] = $category->oxcategories__oxtitle->value;
                 if (!empty($path)) {
                     $this->cachedPaths[$pathId] = implode('/', array_reverse($path));
                     $paths[] = $this->cachedPaths[$pathId];


### PR DESCRIPTION
The top most category is missing in the export.

If an article is in the category "Gear" -> "Fashion" -> "For her" -> "Jeans" only "Fashion/For her/Jeans" was exported.