### PR TITLE
Add session data to ff-communication

### DIFF
--- a/src/Model/Config/Communication.php
+++ b/src/Model/Config/Communication.php
@@ -8,6 +8,7 @@ use Omikron\FactFinder\Oxid\Contract\Config\ParametersSourceInterface;
 use Omikron\FactFinder\Oxid\Export\Filter\TextFilter;
 use OxidEsales\Eshop\Application\Controller\FrontendController;
 use OxidEsales\Eshop\Application\Model\Category;
+use OxidEsales\Eshop\Core\Registry;
 
 class Communication implements ParametersSourceInterface
 {
@@ -29,12 +30,15 @@ class Communication implements ParametersSourceInterface
     public function getParameters(): array
     {
         $category = $this->view->getActiveCategory();
+        $session  = Registry::getSession();
 
         $params = [
             'url'                         => $this->getConfig('ffServerUrl'),
             'version'                     => $this->getConfig('ffApiVersion'),
             'api'                         => $this->getConfig('ffApiVersion') ? 'v3' : '',
             'channel'                     => $this->getConfig('ffChannel'),
+            'sid'                         => substr((string) $session->getId(), 0, 30),
+            'user-id'                     => $session->getUser() ? $session->getUser()->getFieldData('oxcustnr') : '',
             'use-url-parameter'           => $this->getConfig('ffUseUrlParams') ? 'true' : 'false',
             'disable-single-hit-redirect' => 'true',
             'currency-code'               => $this->view->getActCurrency()->name,


### PR DESCRIPTION
- Solves issue: #29 
- Description: Add missing values to `ff-communication` component
- Tested with Oxid EShop editions/versions: EE 6.14
- Tested with PHP versions: 7.1
