### PR TITLE
Export keywords in a dedicated field

### DIFF
--- a/src/Export/ArticleFeed.php
+++ b/src/Export/ArticleFeed.php
@@ -9,6 +9,7 @@ use Omikron\FactFinder\Oxid\Export\Field\Brand;
 use Omikron\FactFinder\Oxid\Export\Field\CategoryPath;
 use Omikron\FactFinder\Oxid\Export\Field\FieldInterface;
 use Omikron\FactFinder\Oxid\Export\Field\FilterAttributes;
+use Omikron\FactFinder\Oxid\Export\Field\Keywords;
 use Omikron\FactFinder\Oxid\Export\Stream\StreamInterface;
 use OxidEsales\Eshop\Core\Registry;
 
@@ -59,6 +60,7 @@ class ArticleFeed
             oxNew(Brand::class),
             oxNew(CategoryPath::class),
             oxNew(FilterAttributes::class),
+            oxNew(Keywords::class),
         ];
     }
 }

--- a/src/Export/Field/Keywords.php
+++ b/src/Export/Field/Keywords.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Omikron\FactFinder\Oxid\Export\Field;
+
+use OxidEsales\Eshop\Application\Model\Article;
+
+class Keywords implements FieldInterface
+{
+    public function getName(): string
+    {
+        return 'Keywords';
+    }
+
+    public function getValue(Article $article, Article $parent): string
+    {
+        return $article->getFieldData('oxsearchkeys') ?: $parent->getFieldData('oxsearchkeys');
+    }
+}


### PR DESCRIPTION
- Solves issue: #32 
- Description: As per our Optimized Feed guide, it is advisable to improve the similarity score by exporting search terms in a dedicated field. Since Oxid offers per default such a field, add it to the product feed.
- Tested with Oxid EShop editions/versions: CE 6.2
- Tested with PHP versions: 7.1
