### PR TITLE
Prevent search event from being triggered twice on result page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## Unreleased
+### Fixed
+- Search event is triggered twice on search result page
+
 ## [v1.0.3] - 2020.11.26
 ### Added
 - Exclude category filter from URL on category pages

--- a/src/views/frontend/widget/search.tpl
+++ b/src/views/frontend/widget/search.tpl
@@ -1,14 +1,13 @@
-<form class="form search" role="form" onsubmit="return false;">
+<div class="form search" role="form">
     <ff-searchbox class="input-group" suggest-onfocus="true" use-suggest="true" select-onclick="true">
         <input type="text" class="form-control" placeholder="[{oxmultilang ident="SEARCH"}]" aria-label="[{oxmultilang ident="SEARCH"}]"/>
-
         <ff-searchbutton class="input-group-btn">
-            <button type="submit" class="btn btn-primary" title="[{oxmultilang ident="SEARCH_SUBMIT"}]">
+            <button type="button" class="btn btn-primary" title="[{oxmultilang ident="SEARCH_SUBMIT"}]">
                 <i class="fa fa-search"></i>
             </button>
         </ff-searchbutton>
     </ff-searchbox>
-</form>
+</div>
 
 [{block name="ff_suggest"}]
     [{include file="ff/suggest.tpl"}]


### PR DESCRIPTION
- Closes #55
- Description: Since the search field was inside of a form, hitting the enter key would trigger a submit. This would also simulate a click event on the `submit` button, probably for event handling. Both events (button click and submit) were triggering events in the library. The HTML was modified by remove the unnecessary form tag and changing the button type to a generic button.
- Tested with Oxid EShop editions/versions: CE 6.2.0
- Tested with PHP versions: 7.1
