### PR TITLE
Do not add master-article to variants

### DIFF
--- a/src/Export/Entity/ArticleEntity.php
+++ b/src/Export/Entity/ArticleEntity.php
@@ -45,8 +45,12 @@ class ArticleEntity implements ExportEntityInterface, DataProviderInterface
 
     public function getEntities(): iterable
     {
-        yield $this;
-        foreach ($this->article->getSimpleVariants() ?? [] as $variant) {
+        $variants = $this->article->getSimpleVariants();
+        if (!$variants) {
+            yield $this;
+            return;
+        }
+        foreach ($variants as $variant) {
             yield new static($variant, $this->article, $this->fields);
         }
     }


### PR DESCRIPTION
- Description: The master product appears as an additional variant in FACT-Finder at the moment, we should remove it from the Feed if it has variants.
- Tested with Oxid EShop editions/versions: EE 6.2.2
- Tested with PHP versions: 7.4