### PR TITLE
FFWEB-2084: add feedback-campaigns blocks to search result page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 ### Changed
 - Upgrade Web Components version to v4.0.3
 
+### Added
+- Add feedback-campaigns blocks to search result page
+
 ## [v1.0.5] - 2021.02.05
 ### Added
 - Introduce `ff-campaign-redirect` component

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 - Upgrade Web Components version to v4.0.3
 
 ### Added
-- Add feedback-campaigns blocks to search result page
+- Add `ff-campaign-feedbacktext` elements to search result page
 
 ## [v1.0.5] - 2021.02.05
 ### Added

--- a/src/views/frontend/blocks/search/result.tpl
+++ b/src/views/frontend/blocks/search/result.tpl
@@ -4,7 +4,7 @@
 
     [{if $oConfig->getConfigParam("ffCampaigns")}]
         [{block name="ff_campaign_feedback_top"}]
-            [{include file="ff/campaign/feedbacktext.tpl" label="above products"}]
+            [{include file="ff/campaign/feedbacktext.tpl" label="above search result"}]
         [{/block}]
     [{/if}]
 
@@ -30,7 +30,7 @@
     </div>
     [{if $oConfig->getConfigParam("ffCampaigns")}]
         [{block name="ff_campaign_feedback_bottom"}]
-            [{include file="ff/campaign/feedbacktext.tpl" label="belove products"}]
+            [{include file="ff/campaign/feedbacktext.tpl" label="below search result"}]
         [{/block}]
     [{/if}]
 </div>

--- a/src/views/frontend/blocks/search/result.tpl
+++ b/src/views/frontend/blocks/search/result.tpl
@@ -1,4 +1,13 @@
 <div class="boxwrapper">
+
+    [{assign var="oConfig" value=$oViewConf->getConfig()}]
+
+    [{if $oConfig->getConfigParam("ffCampaigns")}]
+        [{block name="ff_campaign_feedback_top"}]
+            [{include file="ff/campaign/feedbacktext.tpl" label="above products"}]
+        [{/block}]
+    [{/if}]
+
     [{include file="ff/campaign/search_advisor.tpl"}]
     <div class="toolbar toolbar-top">
         <div class="pull-left">
@@ -19,4 +28,9 @@
             [{include file="ff/paging.tpl"}]
         </div>
     </div>
+    [{if $oConfig->getConfigParam("ffCampaigns")}]
+        [{block name="ff_campaign_feedback_top"}]
+            [{include file="ff/campaign/feedbacktext.tpl" label="belove products"}]
+        [{/block}]
+    [{/if}]
 </div>

--- a/src/views/frontend/blocks/search/result.tpl
+++ b/src/views/frontend/blocks/search/result.tpl
@@ -29,7 +29,7 @@
         </div>
     </div>
     [{if $oConfig->getConfigParam("ffCampaigns")}]
-        [{block name="ff_campaign_feedback_top"}]
+        [{block name="ff_campaign_feedback_bottom"}]
             [{include file="ff/campaign/feedbacktext.tpl" label="belove products"}]
         [{/block}]
     [{/if}]

--- a/src/views/frontend/widget/campaign/feedbacktext.tpl
+++ b/src/views/frontend/widget/campaign/feedbacktext.tpl
@@ -1,1 +1,1 @@
-<ff-campaign-feedbacktext label="[{$label|escape}]" [{$flag|default:"is-product-campaign"}] unresolved>{{{text}}}</ff-campaign-feedbacktext>
+<ff-campaign-feedbacktext label="[{$label|escape}]" unresolved>{{{text}}}</ff-campaign-feedbacktext>


### PR DESCRIPTION
- Fixes 
Web Components Oxid Module Feedback Text implementation for Bergspetzl

- Description: 
Web Components Oxid Module Feedback Text implementation for Bergspetzl

- Tested with Oxid EShop editions/versions: 
6.2.4
- Tested with PHP versions: 
7.3
