### PR TITLE
FFWEB-2098: Fix redirection to search page loses search params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,15 +5,14 @@
 
 ### Added
 - Fields Authorization Prefix and Authorization Postfix are now getting disabled after selecting API version `ng` since they are not relevant for that version
+- Add `ff-campaign-feedbacktext` elements to search result page
  
 ### Fixed
 - Add missing `id-type` attributes to `ff-similar-products` and `ff-campaign-product` elements
+- Fix redirection to search page loses search parameters when shop supports more than one language
 
 ### Changed
 - Upgrade Web Components version to v4.0.3
-
-### Added
-- Add `ff-campaign-feedbacktext` elements to search result page
 
 ## [v1.0.5] - 2021.02.05
 ### Added

--- a/src/views/frontend/blocks/scripts.tpl
+++ b/src/views/frontend/blocks/scripts.tpl
@@ -14,7 +14,9 @@ document.addEventListener('ffReady', function (ff) {
     document.addEventListener('before-search', function (event) {
         if (['productDetail', 'getRecords'].lastIndexOf(event.detail.type) === -1) {
             event.preventDefault();
-            window.location = '[{$oViewConf->getHomeLink()|escape:"javascript"}]' + ff.factfinder.common.dictToParameterString(event.detail) + '&cl=search_result';
+            const baseUrl =  '[{$oViewConf->getHomeLink()|escape:"javascript"}]';
+            const params = ff.factfinder.common.dictToParameterString(factfinder.common.encodeDict(event.detail));
+            window.location = baseUrl + (baseUrl.indexOf('?') > -1 ?  params.substr(1) : params) + '&cl=search_result'
         }
     });
 [{/if}]


### PR DESCRIPTION
- Description: 
Fix redirection to search result page loses parameters where you are in specific language context (having more than one language enabled)
- Tested with Oxid EShop editions/versions: 
6.1.3
- Tested with PHP versions: 
7.3
