### PR TITLE
FFWEB-2117: Fix error with export handler for FilterAttributes does not handle non-string values properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ### Added
 - Introduced cart tracking using Web Components Javascript API
 
+### Fixed
+- Fix error with export handler which is does not handle non-string values properly
+
 ## [v2.0.0] - 2021.07.15
 ### Breaking
 - Communication layer has been entirely replaced with (PHP Communication SDK)[https://github.com/FACT-Finder-Web-Components/php-communication-sdk].

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - Introduced cart tracking using Web Components Javascript API
 
 ### Fixed
-- Fix error with export handler which is does not handle non-string values properly
+- Fix error with export handler which does not handle non-string values properly
 
 ## [v2.0.0] - 2021.07.15
 ### Breaking

--- a/src/Export/Field/FilterAttributes.php
+++ b/src/Export/Field/FilterAttributes.php
@@ -39,7 +39,14 @@ class FilterAttributes extends Attribute implements FieldInterface
             return $this->filter->filterValue($key) . '=' . $this->filter->filterValue($value) . '|';
         }, ...array_map(function (string $value): array {
             return explode(' | ', $value);
-        }, [$parent->getFieldData('oxvarname'), $article->getFieldData('oxvarselect')])));
+        }, [
+            $parent->getFieldData('oxvarname')
+                ? $parent->getFieldData('oxvarname')
+                : 'missing field data',
+            $article->getFieldData('oxvarselect')
+                ? $article->getFieldData('oxvarselect')
+                : 'missing field data'
+        ])));
     }
 
     protected function getAllValues(Article $article): string

--- a/src/Export/Field/FilterAttributes.php
+++ b/src/Export/Field/FilterAttributes.php
@@ -40,8 +40,8 @@ class FilterAttributes extends Attribute implements FieldInterface
         }, ...array_map(function (string $value): array {
             return explode(' | ', $value);
         }, [
-                $parent->getFieldData('oxvarname') ? $parent->getFieldData('oxvarname') : '',
-                $article->getFieldData('oxvarselect') ? $article->getFieldData('oxvarselect') : ''
+                is_string($parent->getFieldData('oxvarname')) ? $parent->getFieldData('oxvarname') : '',
+                is_string($article->getFieldData('oxvarselect')) ? $article->getFieldData('oxvarselect') : ''
             ]
         )));
     }

--- a/src/Export/Field/FilterAttributes.php
+++ b/src/Export/Field/FilterAttributes.php
@@ -40,13 +40,10 @@ class FilterAttributes extends Attribute implements FieldInterface
         }, ...array_map(function (string $value): array {
             return explode(' | ', $value);
         }, [
-            $parent->getFieldData('oxvarname')
-                ? $parent->getFieldData('oxvarname')
-                : 'missing field data',
-            $article->getFieldData('oxvarselect')
-                ? $article->getFieldData('oxvarselect')
-                : 'missing field data'
-        ])));
+                $parent->getFieldData('oxvarname') ? $parent->getFieldData('oxvarname') : 'missing field data',
+                $article->getFieldData('oxvarselect') ? $article->getFieldData('oxvarselect') : 'missing field data'
+            ]
+        )));
     }
 
     protected function getAllValues(Article $article): string
@@ -65,7 +62,7 @@ class FilterAttributes extends Attribute implements FieldInterface
         $result = '';
         foreach (array_intersect_key(parent::getData($article), $this->getMultiAttributes()) as $key => $value) {
             if ($value) {
-                $result .= $this->filter->filterValue($key) . '=' . $this->filter->filterValue((string) $value) . '|';
+                $result .= $this->filter->filterValue($key) . '=' . $this->filter->filterValue((string)$value) . '|';
             }
         }
         return $result;

--- a/src/Export/Field/FilterAttributes.php
+++ b/src/Export/Field/FilterAttributes.php
@@ -35,15 +35,14 @@ class FilterAttributes extends Attribute implements FieldInterface
 
     protected function getVariantValues(Article $article, Article $parent): string
     {
+        $oxvarname = $parent->getFieldData('oxvarname');
+        $oxvarselect = $article->getFieldData('oxvarselect');
+
         return implode('', array_map(function (string $key, string $value): string {
             return $this->filter->filterValue($key) . '=' . $this->filter->filterValue($value) . '|';
         }, ...array_map(function (string $value): array {
             return explode(' | ', $value);
-        }, [
-                is_string($parent->getFieldData('oxvarname')) ? $parent->getFieldData('oxvarname') : '',
-                is_string($article->getFieldData('oxvarselect')) ? $article->getFieldData('oxvarselect') : ''
-            ]
-        )));
+        }, [ $this->validateValueForExport($oxvarname), $this->validateValueForExport($oxvarselect)])));
     }
 
     protected function getAllValues(Article $article): string
@@ -62,7 +61,7 @@ class FilterAttributes extends Attribute implements FieldInterface
         $result = '';
         foreach (array_intersect_key(parent::getData($article), $this->getMultiAttributes()) as $key => $value) {
             if ($value) {
-                $result .= $this->filter->filterValue($key) . '=' . $this->filter->filterValue((string)$value) . '|';
+                $result .= $this->filter->filterValue($key) . '=' . $this->filter->filterValue((string) $value) . '|';
             }
         }
         return $result;
@@ -72,5 +71,10 @@ class FilterAttributes extends Attribute implements FieldInterface
     {
         $this->multiAttributes = $this->multiAttributes ?? array_flip(oxNew(ExportConfig::class)->getMultiAttributes());
         return $this->multiAttributes;
+    }
+
+    private function validateValueForExport(mixed $exportValue): string
+    {
+        return is_numeric($exportValue) || is_string($exportValue) ? $exportValue : '';
     }
 }

--- a/src/Export/Field/FilterAttributes.php
+++ b/src/Export/Field/FilterAttributes.php
@@ -73,7 +73,7 @@ class FilterAttributes extends Attribute implements FieldInterface
         return $this->multiAttributes;
     }
 
-    private function validateValueForExport(mixed $exportValue): string
+    private function validateValueForExport($exportValue): string
     {
         return is_numeric($exportValue) || is_string($exportValue) ? $exportValue : '';
     }

--- a/src/Export/Field/FilterAttributes.php
+++ b/src/Export/Field/FilterAttributes.php
@@ -40,8 +40,8 @@ class FilterAttributes extends Attribute implements FieldInterface
         }, ...array_map(function (string $value): array {
             return explode(' | ', $value);
         }, [
-                $parent->getFieldData('oxvarname') ? $parent->getFieldData('oxvarname') : 'missing field data',
-                $article->getFieldData('oxvarselect') ? $article->getFieldData('oxvarselect') : 'missing field data'
+                $parent->getFieldData('oxvarname') ? $parent->getFieldData('oxvarname') : '',
+                $article->getFieldData('oxvarselect') ? $article->getFieldData('oxvarselect') : ''
             ]
         )));
     }

--- a/src/Export/Field/FilterAttributes.php
+++ b/src/Export/Field/FilterAttributes.php
@@ -75,6 +75,6 @@ class FilterAttributes extends Attribute implements FieldInterface
 
     private function validateValueForExport($exportValue): string
     {
-        return is_numeric($exportValue) || is_string($exportValue) ? $exportValue : '';
+        return is_numeric($exportValue) || is_string($exportValue) ? (string) $exportValue : '';
     }
 }


### PR DESCRIPTION
- Fixes
#74 
- Description: 
Fix error with export handler for FilterAttributes does not handle non-string values properly
- Tested with Oxid EShop editions/versions: 
6.2.4
- Tested with PHP versions: 
7.3
