### PR TITLE
FFWEB-2167: Add HTML5 validation for URL and FTP fields

### DIFF
--- a/src/metadata.php
+++ b/src/metadata.php
@@ -48,6 +48,16 @@ $aModule = [
             'file'     => 'views/admin/blocks/factfinder_config_field_api_version.tpl',
         ],
         [
+            'template' => 'module_config.tpl',
+            'block'    => 'admin_module_config_var_type_str',
+            'file'     => 'views/admin/blocks/factfinder_config_field_server_url.tpl',
+        ],
+        [
+            'template' => 'module_config.tpl',
+            'block'    => 'admin_module_config_var_type_str',
+            'file'     => 'views/admin/blocks/factfinder_config_field_ftp_host.tpl',
+        ],
+        [
             'template' => 'layout/base.tpl',
             'block'    => 'head_css',
             'file'     => 'views/frontend/blocks/scripts.tpl',

--- a/src/out/admin/css/styles.css
+++ b/src/out/admin/css/styles.css
@@ -45,3 +45,16 @@ input[type="button"].row-remove {
     margin: 0;
     border: 0;
 }
+
+input[type="url"], select {
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    box-shadow: 0 1px 1px rgba(0, 0, 0, .075) inset;
+    color: #555;
+    min-height: 15px;
+    line-height: 1.42857;
+    padding: 3px;
+    font-size: 12px;
+    transition: border-color 0.15s ease-in-out 0s, box-shadow 0.15s ease-in-out 0s;
+    background: #fff;
+}

--- a/src/views/admin/blocks/factfinder_config_field_ftp_host.tpl
+++ b/src/views/admin/blocks/factfinder_config_field_ftp_host.tpl
@@ -1,0 +1,6 @@
+[{if $module_var === 'ffFtpHost'}]
+<input type=text  class="txt" style="width: 250px;" name="confstrs[[{$module_var}]]" value="[{$confstrs.$module_var}]" [{$readonly}]
+pattern="^(ftp:\/\/|ftps:\/\/)[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,5}(:[0-9]{1,5})?(\/.*)?$">
+[{else}]
+    [{$smarty.block.parent}]
+[{/if}]

--- a/src/views/admin/blocks/factfinder_config_field_server_url.tpl
+++ b/src/views/admin/blocks/factfinder_config_field_server_url.tpl
@@ -1,0 +1,5 @@
+[{if $module_var === 'ffServerUrl'}]
+<input type=url  class="txt" style="width: 250px;" name="confstrs[[{$module_var}]]" value="[{$confstrs.$module_var}]" [{$readonly}]>
+[{else}]
+    [{$smarty.block.parent}]
+[{/if}]


### PR DESCRIPTION
- Fixes
FFWEB-2167

- Description: 
Add validation for url and frp fields

- Tested with Oxid EShop editions/versions: 
6.2.4

- Tested with PHP versions: 
7.3.28
