### PR TITLE
FFWEB-2253: Fix channel field rendering and saving in configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## [v3.0.1] - 2021.10.08
+### Fixed
+- Fix Configuration error for the channel field rendering/saving
+
 ## [v3.0.0] - 2021.09.23
 ### Breaking
 - Omikron\FactFinder\Oxid\Export\Entity\DataProvider

--- a/src/Controller/Admin/ModuleConfiguration.php
+++ b/src/Controller/Admin/ModuleConfiguration.php
@@ -27,7 +27,8 @@ class ModuleConfiguration extends ModuleConfiguration_parent
 
             $this->addTplParam('shopLanguages', Registry::getLang()->getActiveShopLanguageIds());
             $this->addTplParam('localizedFields', array_reduce($this->localizedFields, function (array $result, string $field): array {
-                return [$field => $this->_aarrayToMultiline($result[$field] ?? [])] + $result;
+                $value = html_entity_decode($this->getViewDataElement('confaarrs')[$field] ?? '');
+                return $result + [$field => $this->_multilineToAarray($value)];
             }, []));
             $this->addTplParam('availableAttributes', $allAttributes);
             $this->addTplParam('selectedAttributes', $this->getSelectedAttributes($allAttributes));
@@ -39,8 +40,7 @@ class ModuleConfiguration extends ModuleConfiguration_parent
     {
         if ($this->isFactFinder()) {
             $_POST['confaarrs'] = array_reduce($this->localizedFields, function (array $result, string $field): array {
-                $value = html_entity_decode($this->getViewDataElement('confaarrs')[$field] ?? '');
-                return $result + [$field => $this->_multilineToAarray($value)];
+                return [$field => $this->_aarrayToMultiline($result[$field] ?? [])] + $result;
             }, $_POST['confaarrs'] ?? []);
 
             $_POST['confaarrs']['ffExportAttributes'] = $this->_aarrayToMultiline(


### PR DESCRIPTION
- Description: 
Field channel is not correctly rendered and saved to the databases
- Tested with Oxid EShop editions/versions: 
EE 6.3
- Tested with PHP versions: 
8.0, 7.4
