### PR TITLE
FFWEB-2276: Declare PHP 8.0 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+## [v4.0.1]
+### Changed
+ Compatibility
+  - Declare PHP8.0 compatibility
+
 ## [v4.0.0]
 ### Breaking
  - Drop php7.1 version support
@@ -88,6 +93,7 @@
 ## [v1.0.0] - 2020.09.14
 Initial module release. Includes Web Components v3.15.6
 
+[v4.0.1]:  https://github.com/FACT-Finder-Web-Components/oxid-eshop-module/releases/tag/v4.0.1
 [v4.0.0]:  https://github.com/FACT-Finder-Web-Components/oxid-eshop-module/releases/tag/v4.0.0
 [v3.0.1]:  https://github.com/FACT-Finder-Web-Components/oxid-eshop-module/releases/tag/v3.0.1
 [v3.0.0]:  https://github.com/FACT-Finder-Web-Components/oxid-eshop-module/releases/tag/v3.0.0

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "php": ">=7.2",
     "ext-ftp": "*",
     "ext-json": "*",
-    "omikron/factfinder-communication-sdk": "dev-8.0-support",
+    "omikron/factfinder-communication-sdk": "^0.9",
     "league/flysystem-sftp": "^2.2",
     "league/flysystem-ftp": "^2.3"
   },

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     }
   ],
   "require": {
-    "php": "^7.2",
+    "php": ">=7.2",
     "ext-ftp": "*",
     "ext-json": "*",
     "omikron/factfinder-communication-sdk": "^0.9",

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "php": ">=7.2",
     "ext-ftp": "*",
     "ext-json": "*",
-    "omikron/factfinder-communication-sdk": "^0.9",
+    "omikron/factfinder-communication-sdk": "dev-8.0-support",
     "league/flysystem-sftp": "^2.2",
     "league/flysystem-ftp": "^2.3"
   },


### PR DESCRIPTION
- Description: 
Declare php8.0 compatibility
- Tested with Oxid EShop editions/versions: 
6.3
- Tested with PHP versions: 
8.0
