### PR TITLE
FFWEB-2319: Add scroll to top for category page and search result page after changing page in pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+## Unreleased
+### Added
+ - Add scroll to top on pagination for category page and search result page
+
+
 ## [v4.0.1]
 ### Changed
  Compatibility

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,7 @@
 # Changelog
 ## Unreleased
 ### Added
- - Add scroll to top on pagination for category page and search result page
-
+ - add scroll to top callback after products page change
 
 ## [v4.0.1]
 ### Changed

--- a/src/Model/Config/Communication.php
+++ b/src/Model/Config/Communication.php
@@ -9,7 +9,6 @@ use Omikron\FactFinder\Oxid\Export\Filter\TextFilter;
 use OxidEsales\Eshop\Application\Controller\FrontendController;
 use OxidEsales\Eshop\Application\Model\Category;
 use OxidEsales\Eshop\Core\Registry;
-use RuntimeException;
 
 class Communication implements ParametersSourceInterface
 {

--- a/src/Model/Config/Communication.php
+++ b/src/Model/Config/Communication.php
@@ -117,7 +117,7 @@ class Communication implements ParametersSourceInterface
         $channels = $this->getConfig('ffChannel');
 
         if (!isset($channels[$langAbbr])) {
-            return '';
+            throw new RuntimeException("No channel for used language: $langAbbr");
         }
 
         return $channels[$langAbbr];

--- a/src/Model/Config/Communication.php
+++ b/src/Model/Config/Communication.php
@@ -118,7 +118,7 @@ class Communication implements ParametersSourceInterface
         $channels = $this->getConfig('ffChannel');
 
         if (!isset($channels[$langAbbr])) {
-            throw new RuntimeException("No channel for used language: $langAbbr");
+            return '';
         }
 
         return $channels[$langAbbr];

--- a/src/out/js/utils.js
+++ b/src/out/js/utils.js
@@ -1,0 +1,17 @@
+function scroll (selector, config) {
+    return function() {
+        const defaultConfig = {
+            behavior: 'smooth',
+            top: 0,
+            left: 0
+        };
+        const mergedConfig = Object.assign({}, defaultConfig, config);
+
+        if (selector) {
+            const element = document.querySelector(selector);
+            !element ? console.error('Invalid selector', selector) : element.scrollIntoView(mergedConfig);
+        } else {
+            window.scrollTo(mergedConfig);
+        }
+    }
+}

--- a/src/views/frontend/blocks/scripts.tpl
+++ b/src/views/frontend/blocks/scripts.tpl
@@ -4,6 +4,7 @@
 <script src="[{$oViewConf->getModuleUrl('ffwebcomponents', 'out/js/ff-web-components/vendor/custom-elements-es5-adapter.js')|escape}]"></script>
 <script src="[{$oViewConf->getModuleUrl('ffwebcomponents', 'out/js/ff-web-components/vendor/webcomponents-loader.js')|escape}]"></script>
 <script src="[{$oViewConf->getModuleUrl('ffwebcomponents', 'out/js/ff-web-components/bundle.js')|escape}]" defer></script>
+<script src="[{$oViewConf->getModuleUrl("ffwebcomponents", "out/js/utils.js")|escape}]"></script>
 <style>[unresolved]{opacity:0;display:none}</style>
 
 <script>

--- a/src/views/frontend/widget/record_list.tpl
+++ b/src/views/frontend/widget/record_list.tpl
@@ -36,27 +36,11 @@
 
 
 <script>
-    function scrollToCallback (selector, config) {
-        debugger
-        const defaultConfig = {
-            behavior: 'smooth',
-            top: 0,
-            left: 0
-        };
-        const mergedConfig = Object.assign({}, defaultConfig, config);
-
-        if (selector) {
-            const element = document.querySelector(selector);
-            !element ? console.error('Invalid selector', selector) : element.scrollIntoView(mergedConfig);
-        } else {
-            window.scrollTo(mergedConfig);
-        }
-    }
-
     document.addEventListener('ffReady', function (ff) {
-        factfinder.communication.EventAggregator.addBeforeDispatchingCallback(function (event) {
+        ff.eventAggregator.addBeforeDispatchingCallback(function (event) {
             if (event.type === 'search' || event.type === 'paging') {
-                event.success = factfinder.common.concatFunctions(event.success, scrollToCallback());
+                const scrollCallback = scroll();
+                event.success = factfinder.common.concatFunctions(event.success, scrollCallback);
             }
         });
     });

--- a/src/views/frontend/widget/record_list.tpl
+++ b/src/views/frontend/widget/record_list.tpl
@@ -33,3 +33,31 @@
         </form>
     </ff-record>
 </ff-record-list>
+
+
+<script>
+    function scrollToCallback (selector, config) {
+        debugger
+        const defaultConfig = {
+            behavior: 'smooth',
+            top: 0,
+            left: 0
+        };
+        const mergedConfig = Object.assign({}, defaultConfig, config);
+
+        if (selector) {
+            const element = document.querySelector(selector);
+            !element ? console.error('Invalid selector', selector) : element.scrollIntoView(mergedConfig);
+        } else {
+            window.scrollTo(mergedConfig);
+        }
+    }
+
+    document.addEventListener('ffReady', function (ff) {
+        factfinder.communication.EventAggregator.addBeforeDispatchingCallback(function (event) {
+            if (event.type === 'search' || event.type === 'paging') {
+                event.success = factfinder.common.concatFunctions(event.success, scrollToCallback());
+            }
+        });
+    });
+</script>


### PR DESCRIPTION
- Fixes
FFWEB-2319

- Description: 
Add scroll to top for category page and search result page after changing page in pagination

- Tested with Oxid EShop editions/versions: 
6.2.5

- Tested with PHP versions: 
7.4.20
