### PR TITLE
FFWEB-2334: Add long description to category export

### DIFF
--- a/src/Export/CategoryFeed.php
+++ b/src/Export/CategoryFeed.php
@@ -23,6 +23,7 @@ class CategoryFeed extends AbstractFeed
         'Name',
         'ImageUrl',
         'Description',
+        'LongDescription',
     ];
 
     public function __construct(FieldInterface ...$fields)

--- a/src/Export/Entity/CategoryEntity.php
+++ b/src/Export/Entity/CategoryEntity.php
@@ -43,15 +43,15 @@ class CategoryEntity implements DataProviderInterface, ExportEntityInterface
     public function toArray(): array
     {
         $data = [
-            'Id'           => $this->category->getFieldData('oxid'),
-            'ShopId'       => $this->category->getFieldData('oxshopid'),
-            'ExternalLink' => $this->category->getFieldData('oxextlink'),
-            'ParentId'     => $this->category->getFieldData('oxparentid'),
-            'RootId'       => $this->category->getFieldData('oxrootid'),
-            'Name'         => $this->category->getFieldData('oxtitle'),
-            'ImageUrl'     => $this->category->getPictureUrl(),
-            'Description'  => $this->category->getFieldData('oxdesc'),
-            'LongDescription'  => $this->category->getFieldData('oxlongdesc'),
+            'Id'              => $this->category->getFieldData('oxid'),
+            'ShopId'          => $this->category->getFieldData('oxshopid'),
+            'ExternalLink'    => $this->category->getFieldData('oxextlink'),
+            'ParentId'        => $this->category->getFieldData('oxparentid'),
+            'RootId'          => $this->category->getFieldData('oxrootid'),
+            'Name'            => $this->category->getFieldData('oxtitle'),
+            'ImageUrl'        => $this->category->getPictureUrl(),
+            'Description'     => $this->category->getFieldData('oxdesc'),
+            'LongDescription' => $this->category->getFieldData('oxlongdesc'),
         ];
 
         return array_reduce($this->fields, function (array $result, FieldInterface $field): array {

--- a/src/Export/Entity/CategoryEntity.php
+++ b/src/Export/Entity/CategoryEntity.php
@@ -51,6 +51,7 @@ class CategoryEntity implements DataProviderInterface, ExportEntityInterface
             'Name'         => $this->category->getFieldData('oxtitle'),
             'ImageUrl'     => $this->category->getPictureUrl(),
             'Description'  => $this->category->getFieldData('oxdesc'),
+            'LongDescription'  => $this->category->getFieldData('oxlongdesc'),
         ];
 
         return array_reduce($this->fields, function (array $result, FieldInterface $field): array {


### PR DESCRIPTION
- Description: 
Export `oxlongdesc` field in category export
- Tested with Oxid EShop editions/versions: 
EE 6.3.0
- Tested with PHP versions:
8.0
