### PR TITLE
FFWEB-2352: RuntimeException not found 4 0 2

### DIFF
--- a/src/Model/Config/Communication.php
+++ b/src/Model/Config/Communication.php
@@ -117,7 +117,7 @@ class Communication implements ParametersSourceInterface
         $channels = $this->getConfig('ffChannel');
 
         if (!isset($channels[$langAbbr])) {
-            throw new RuntimeException("No channel for used language: $langAbbr");
+            throw new \RuntimeException("No channel for used language: $langAbbr");
         }
 
         return $channels[$langAbbr];

--- a/src/Model/Config/Communication.php
+++ b/src/Model/Config/Communication.php
@@ -9,6 +9,7 @@ use Omikron\FactFinder\Oxid\Export\Filter\TextFilter;
 use OxidEsales\Eshop\Application\Controller\FrontendController;
 use OxidEsales\Eshop\Application\Model\Category;
 use OxidEsales\Eshop\Core\Registry;
+use RuntimeException;
 
 class Communication implements ParametersSourceInterface
 {
@@ -117,7 +118,7 @@ class Communication implements ParametersSourceInterface
         $channels = $this->getConfig('ffChannel');
 
         if (!isset($channels[$langAbbr])) {
-            throw new \RuntimeException("No channel for used language: $langAbbr");
+            throw new RuntimeException("No channel for used language: $langAbbr");
         }
 
         return $channels[$langAbbr];


### PR DESCRIPTION
- Fixes
https://jira.omikron.net/browse/FFWEB-2352

- Description: 
Fix customer's error with missing RuntimeException class

- Tested with Oxid EShop editions/versions: 
6.2.5

- Tested with PHP versions: 
- 7.4.20
