### PR TITLE
FFWEB-2365: Use raw values for attribute titles instead of html decoded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - fix missing use of RuntimeException in Communication.php
 - restored setting `currency-country-code` in Communication.php
 - restored version="v4" in Communication.php
+- fix Attributes with " (quote) causes export field setting to break 
 
 ### Changed
  - removed `disable-single-hit-redirect` from Communication.php. This attribute no longer exist

--- a/src/Controller/Admin/ModuleConfiguration.php
+++ b/src/Controller/Admin/ModuleConfiguration.php
@@ -59,7 +59,7 @@ class ModuleConfiguration extends ModuleConfiguration_parent
     {
         $attributeList = oxNew(AttributeList::class)->getList()->getArray();
         return array_reduce($attributeList, function (array $attributes, Attribute $attribute): array {
-            return $attributes + [$attribute->getFieldData('oxid') => $attribute->getFieldData('oxtitle')];
+            return $attributes + [$attribute->getFieldData('oxid') => $attribute->oxattribute__oxtitle->rawValue];
         }, []);
     }
 

--- a/src/Export/AbstractFeed.php
+++ b/src/Export/AbstractFeed.php
@@ -4,10 +4,8 @@ declare(strict_types=1);
 
 namespace Omikron\FactFinder\Oxid\Export;
 
-use Omikron\FactFinder\Oxid\Export\Field\Attribute as AttributeField;
 use Omikron\FactFinder\Oxid\Export\Field\FieldInterface;
 use Omikron\FactFinder\Oxid\Export\Stream\StreamInterface;
-use Omikron\FactFinder\Oxid\Model\Config\Export as ExportConfig;
 use OxidEsales\Eshop\Core\Registry;
 use ReflectionClass;
 
@@ -34,12 +32,5 @@ abstract class AbstractFeed
     protected function getFieldName(FieldInterface $field): string
     {
         return $field->getName();
-    }
-
-    protected function getConfigFields(): array
-    {
-        return array_map(function (string $attribute): FieldInterface {
-            return oxNew(AttributeField::class, $attribute);
-        }, array_values(oxNew(ExportConfig::class)->getSingleFields()));
     }
 }

--- a/src/Model/Config/Export.php
+++ b/src/Model/Config/Export.php
@@ -36,7 +36,7 @@ class Export
     {
         $this->attributes = $this->attributes ?? oxNew(AttributeList::class)->getList()->getArray();
         return array_map(function (BaseModel $attribute): string {
-            return $attribute->getFieldData('oxtitle');
+            return $attribute->oxattribute__oxtitle->rawValue;
         }, $this->attributes);
     }
 }


### PR DESCRIPTION
- Fixes # 
#93 
- Tested with Oxid EShop editions/versions: 
EE 6.3
- Tested with PHP versions: 
8.0
