### PR TITLE
FFWEB-2304 Encoding category path fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## Unreleased
+### Fix
+ - Fix filters could not be deselected on some category pages 
+ 
 ## [v4.1.0] - 2022.02.11
 ### Add
 - implement `category-page` attribute

--- a/src/Model/Config/Communication.php
+++ b/src/Model/Config/Communication.php
@@ -149,7 +149,7 @@ class Communication implements ParametersSourceInterface
 
     private function encodeCategoryName(string $path): string
     {
-        //important! do not override this method
+        //important! do not modify this code
         return preg_replace('/\+/', '%2B',
             preg_replace('/\//', '%2F', preg_replace('/%/', '%25', $path)));
     }

--- a/src/Model/Config/Communication.php
+++ b/src/Model/Config/Communication.php
@@ -128,29 +128,29 @@ class Communication implements ParametersSourceInterface
 
     private function ngPath(array $categories, string $param): string
     {
-        $categoryPath = implode(urlencode('/'), array_map(function ($category) {
-            return $this->plusDoubleEncode($category);
-        }, array_reverse($categories)));
+        $categoryPath = array_map(function ($category) {
+            return (string) $this->encodeCategoryName(trim($category));
+        }, array_reverse($categories));
 
-        return sprintf('filter=%s%s', urlencode("$param:"), $categoryPath);
+        return sprintf('filter=%s', urlencode($param . ':' . implode('/', $categoryPath)));
     }
 
     private function standardPath(array $categories, string $param): string
     {
-        $categoriesReverse = array_reverse($categories);
         $path              = 'ROOT';
         $value             = ['navigation=true'];
-        foreach ($categoriesReverse as $key => $category) {
-            $path .= $key === 0 ? null : urlencode('/') . $this->plusDoubleEncode($categoriesReverse[$key - 1]);
-            $parameterKey = urlencode($param) . $path;
-            $value[]      = sprintf('filter%s=%s', $parameterKey, urlencode($category));
+        foreach (array_reverse($categories) as $category) {
+            $value[] = sprintf("filter{$param}%s=%s", $path, urlencode(trim($category)));
+            $path .= urlencode('/' . $this->encodeCategoryName(trim($category)));
         }
 
         return implode(',', $value);
     }
 
-    private function plusDoubleEncode(string $path): string
+    private function encodeCategoryName(string $path): string
     {
-        return urlencode(str_replace('+', ' ', urlencode($path)));
+        //important! do not override this method
+        return preg_replace('/\+/', '%2B',
+            preg_replace('/\//', '%2F', preg_replace('/%/', '%25', $path)));
     }
 }


### PR DESCRIPTION
- Description: 
Encode twice `%`, `/` and `+` characters when creates category path filter
- Tested with Oxid EShop editions/versions: 
6.3 EE
- Tested with PHP versions: 
8.0
