### PR TITLE
FFWEB-2422 fix FtpParams does not return stored configuration release/3.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## Unreleased
+### Fix
+ - fix `Omikron\FactFinder\Oxid\Model\Config\FtpParams` does not return stored configuration 
+ 
 ## [v3.1.1] - 2022.02.21
 ### Fix
  - fix category names are fully encoded twice in `ff-communication/category-page`

--- a/src/Model/Config/FtpParams.php
+++ b/src/Model/Config/FtpParams.php
@@ -21,27 +21,27 @@ class FtpParams
 
     public function getType(): string
     {
-        return (string) $this->overrides['type'] ?? $this->config->getConfigParam('ffFtpType');
+        return (string) ($this->overrides['type'] ?? $this->config->getConfigParam('ffFtpType'));
     }
 
     public function getHost(): string
     {
-        return (string) $this->overrides['host'] ?? $this->config->getConfigParam('ffFtpHost');
+        return (string) ($this->overrides['host'] ?? $this->config->getConfigParam('ffFtpHost'));
     }
 
     public function getPort(): int
     {
-        return (int) $this->overrides['port'] ?? $this->config->getConfigParam('ffFtpPort');
+        return (int) ($this->overrides['port'] ?? $this->config->getConfigParam('ffFtpPort'));
     }
 
     public function getUser(): string
     {
-        return (string) $this->overrides['username'] ?? $this->config->getConfigParam('ffFtpUser');
+        return (string) ($this->overrides['username'] ?? $this->config->getConfigParam('ffFtpUser'));
     }
 
     public function getPassword(): string
     {
-        return (string) $this->overrides['password'] ?? $this->config->getConfigParam('ffFtpPassword');
+        return (string) ($this->overrides['password'] ?? $this->config->getConfigParam('ffFtpPassword'));
     }
 
     public function useSsl(): bool
@@ -51,17 +51,17 @@ class FtpParams
 
     public function getPrivateKey(): string
     {
-        return (string) trim($this->overrides['privateKey'] ?? $this->config->getConfigParam('ffFtpKey'));
+        return trim((string) ($this->overrides['privateKey'] ?? $this->config->getConfigParam('ffFtpKey')));
     }
 
     public function getRoot(): string
     {
-        return (string) $this->overrides['root'] ?? $this->config->getConfigParam('ffFtpRoot');
+        return (string) ($this->overrides['root'] ?? $this->config->getConfigParam('ffFtpRoot'));
     }
 
     public function getKeyPassphrase(): string
     {
-        return (string) $this->overrides['passphrase'] ?? $this->config->getConfigParam('ffFtpKeyPassphrase');
+        return (string) ($this->overrides['passphrase'] ?? $this->config->getConfigParam('ffFtpKeyPassphrase'));
     }
 
     public function toArray(): array


### PR DESCRIPTION
- Description:
Fix FtpParams does not return stored configuration
- Tested with Oxid EShop editions/versions: 
6.3 EE
- Tested with PHP versions: 
8.0

