### PR TITLE
FFWEB-2127: hide category filter on category page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ### Add
  - add Update FieldRoles functionality that allows user to store Field Roles received from FACT-Finder search response in shop configuration
  
+### Change
+ - category filter is hidden on the category page 
+ 
 ### Fix
  - fix scrollTop top page is executed on search immediate event
  - fix `src/Export/Field/FilterAttributes` exports attribute selection from variant product level

--- a/src/views/frontend/widget/asn.tpl
+++ b/src/views/frontend/widget/asn.tpl
@@ -1,6 +1,32 @@
 <div class="ff-asn">
     <p class="text-uppercase h6 hidden-sm-down">[{oxmultilang ident="FF_FILTER_BY"}]</p>
     <ff-asn align="vertical" unresolved>
+
+        <ff-asn-group for-group="CategoryPathROOT"   [{if $oView->getClassKey() eq "alist"}] class="hidden" [{/if}]>
+            <div slot="groupCaption" class="groupCaption">
+                <p class="h4 facet-title hidden-sm-down">{{group.name}}</p>
+            </div>
+
+            <ff-asn-group-element>
+                <div slot="selected">
+                    <span class="custom-checkbox">
+                        <input type="checkbox" checked />
+                        <span class="filterName">{{element.name}}</span>
+                    </span>
+                </div>
+                <div slot="unselected">
+                    <span class="custom-checkbox">
+                        <input type="checkbox" />
+                        <span class="filterName">{{element.name}}</span>
+                    </span>
+                </div>
+
+                <div data-container="removeFilter">[{oxmultilang ident="FF_REMOVE_FILTER"}]</div>
+                <div data-container="showMore">[{oxmultilang ident="FF_SHOW_MORE"}]</div>
+                <div data-container="showLess">[{oxmultilang ident="FF_SHOW_LESS"}]</div>
+            </ff-asn-group-element>
+        </ff-asn-group>
+
         <ff-asn-group class="facet clearfix">
             <div slot="groupCaption" class="groupCaption">
                 <p class="h4 facet-title hidden-sm-down">{{group.name}}</p>


### PR DESCRIPTION
- Description: 
hide the category filter on the category page
- Tested with Oxid EShop editions/versions: 
6.3 EE
- Tested with PHP versions: 
8.0
