### PR TITLE
FFWEB-2595 - fixed tracking after variant change, passing proper numb…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Changelog
 ## Unreleased
 ### Add
- - add anonymize functionality that anonymize `user-id` parameter in any tracking request sent to FACT-Finder  
+ - add anonymize functionality that anonymize `user-id` parameter in any tracking request sent to FACT-Finder
+### Fix
+ - fixed tracking after variant change
+ - passing proper number of products in the basket after checkout
  
 ## [v4.3.0] - 2022.07.11
 ### Add

--- a/src/views/frontend/blocks/campaign/product.tpl
+++ b/src/views/frontend/blocks/campaign/product.tpl
@@ -1,5 +1,4 @@
 [{$smarty.block.parent}]
-<script src="[{$oViewConf->getModuleUrl("ffwebcomponents", "out/js/tracking.js")|escape}]"></script>
 [{assign var="oConfig" value=$oViewConf->getConfig()}]
 [{assign var="recordId" value=$oView->getProduct()|record_id}]
 

--- a/src/views/frontend/blocks/order/tracking.tpl
+++ b/src/views/frontend/blocks/order/tracking.tpl
@@ -4,7 +4,7 @@
 [{foreach from=$order->getOrderArticles() item="oArticle"}]
     [{assign var="aPrice" value=$oArticle->getPrice()}]
     <ff-checkout-tracking-item record-id="[{$oArticle|record_id:"oxorderarticles"|escape}]"
-                               count="[{$oArticle->oxorderarticles_oxamount}]"
+                               count="[{$oArticle->oxorderarticles__oxamount}]"
                                price="[{$aPrice->getNettoPrice()|@number_format:2:".":""}]"></ff-checkout-tracking-item>
 [{/foreach}]
 </ff-checkout-tracking>

--- a/src/views/frontend/blocks/scripts.tpl
+++ b/src/views/frontend/blocks/scripts.tpl
@@ -51,3 +51,7 @@ document.addEventListener('ffReady', function (ff) {
 [{/if}]
 });
 </script>
+
+[{if $oView->getClassKey() eq "details"}]
+<script src="[{$oViewConf->getModuleUrl("ffwebcomponents", "out/js/tracking.js")|escape}]"></script>
+[{/if}]


### PR DESCRIPTION
 - Fixes:
   - FFWEB-2533 
 - Description:
   - fixed tracking after variant change
   - passing proper number of products in the basket after checkout
 - Tested with Oxid EShop editions/versions:
   - 6.4 CE
 - Tested with PHP versions:
   - 7.4