### PR TITLE
FFWEB-2615 - remove undesired params

### DIFF
--- a/src/Component/Widget/WebComponent.php
+++ b/src/Component/Widget/WebComponent.php
@@ -29,6 +29,6 @@ class WebComponent extends WidgetController
 
     public function getSearchImmediate(): bool
     {
-        return (bool) $this->config->getParameters()['search-immediate'];
+        return $this->config->getParameters()['search-immediate'] === 'true';
     }
 }

--- a/src/Model/Config/Communication.php
+++ b/src/Model/Config/Communication.php
@@ -51,9 +51,7 @@ class Communication implements ParametersSourceInterface
             'only-search-params'    => 'true',
             'use-browser-history'   => 'true',
             'category-page'         => $this->getConfig('ffApiVersion') === 'ng' && $this->useForCategories() ? $this->getCategoryPath($category) : null,
-            'add-params'            => $this->getConfig('ffApiVersion') === 'ng'
-                ? ($this->useForCategories() ? null : 'cl=search_result')
-                : ($this->useForCategories() ? $this->getCategoryPath($category) : 'cl=search_result'),
+            'add-params'            => $this->getConfig('ffApiVersion') !== 'ng' && $this->useForCategories() ? $this->getCategoryPath($category) : '',
         ];
 
         return array_filter($this->mergeParameters($params, $this->getAdditionalParameters()));


### PR DESCRIPTION
 - Fixes:
   - FFWEB-2615
 - Description:
   - Removed query and cl=search_result parameters from pages without search results
 - Tested with Oxid EShop editions/versions:
   - 6.4 CE
 - Tested with PHP versions:
   - 7.4