### PR TITLE
FFWEB-2642: Fix user login tracking event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Changelog
+## Unreleased
+### Add
+- Add option to switch between Api Version
+### Fix
+- Fix problme with user login tracking event
+
 ## [v4.3.5] - 2022.12.12
 ### Fix
 - Fix cart tracking

--- a/src/Model/Config/Communication.php
+++ b/src/Model/Config/Communication.php
@@ -65,7 +65,7 @@ class Communication implements ParametersSourceInterface
             return '';
         }
 
-        $userId = $session->getUser()->getFieldData('oxcustnr');
+        $userId = (string) $session->getUser()->getFieldData('oxcustnr');
 
         return $this->getConfig('ffAnonymizeUserId') ? md5($userId) : $userId;
     }

--- a/src/Subscriber/AfterRequestProcessedEventSubscriber.php
+++ b/src/Subscriber/AfterRequestProcessedEventSubscriber.php
@@ -6,12 +6,16 @@ namespace Omikron\FactFinder\Oxid\Subscriber;
 
 use OxidEsales\Eshop\Core\Config;
 use OxidEsales\Eshop\Core\Registry;
+use OxidEsales\Eshop\Core\Request;
 use OxidEsales\Eshop\Core\Session;
 use OxidEsales\EshopCommunity\Internal\Framework\Event\AbstractShopAwareEventSubscriber;
 use OxidEsales\EshopCommunity\Internal\Transition\ShopEvents\AfterRequestProcessedEvent;
 
 class AfterRequestProcessedEventSubscriber extends AbstractShopAwareEventSubscriber
 {
+    /** @var Request */
+    private $request;
+
     /** @var Session */
     private $session;
 
@@ -19,9 +23,11 @@ class AfterRequestProcessedEventSubscriber extends AbstractShopAwareEventSubscri
     private $config;
 
     public function __construct(
+        ?Request $request = null,
         ?Session $session = null,
         ?Config $config = null
     ) {
+        $this->request = $request ?? Registry::getRequest();
         $this->session = $session ?? Registry::getSession();
         $this->config  = $config ?? Registry::getConfig();
     }
@@ -49,7 +55,7 @@ class AfterRequestProcessedEventSubscriber extends AbstractShopAwareEventSubscri
     {
         $user = $this->session->getUser();
 
-        if (empty($user)) {
+        if (empty($user) && $this->request->getRequestParameter('fnc') === 'logout') {
             $this->session->setVariable(BeforeHeadersSendEventSubscriber::HAS_JUST_LOGGED_OUT, true);
         }
     }


### PR DESCRIPTION
 - Fixes:
   - FFWEB-2642
 - Description:
   - Fix user login tracking event
 - Tested with Oxid EShop editions/versions:
   - 6.4 CE
 - Tested with PHP versions:
   - 7.4, 8.1