### PR TITLE
FFWEB-2701: Add disable-cache param in shop configuration and ff-communication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## Unreleased
 ### Add
 - Export category for suggest
+- Disable-cache param in shop configuration and ff-communication
 
 ## [v4.4.1] - 2023.03.08
 ### Add

--- a/src/Model/Config/Communication.php
+++ b/src/Model/Config/Communication.php
@@ -52,6 +52,7 @@ class Communication implements ParametersSourceInterface
             'use-browser-history'   => 'true',
             'category-page'         => $this->getConfig('ffVersion') === 'ng' && $this->useForCategories() ? $this->getCategoryPath($category) : null,
             'add-params'            => $this->getConfig('ffVersion') !== 'ng' && $this->useForCategories() ? $this->getCategoryPath($category) : '',
+            'disable-cache'         => $this->getConfig('ffDisableCache') ? 'true' : 'false',
         ];
 
         return array_filter($this->mergeParameters($params, $this->getAdditionalParameters()));

--- a/src/metadata.php
+++ b/src/metadata.php
@@ -276,6 +276,13 @@ $aModule = [
             'position' => $settingPosition++,
         ],
         [
+            'group'    => 'ffFeatures',
+            'name'     => 'ffDisableCache',
+            'type'     => 'bool',
+            'value'    => false,
+            'position' => $settingPosition++,
+        ],
+        [
             'group'    => 'ffFeed',
             'name'     => 'ffExportAttributes',
             'type'     => 'aarr',

--- a/src/views/admin/de/ffwebcomponents_lang.php
+++ b/src/views/admin/de/ffwebcomponents_lang.php
@@ -41,6 +41,7 @@ $aLang = [
     'SHOP_MODULE_ffRecommendations'                              => 'Empfehlungen',
     'SHOP_MODULE_ffSimilarProducts'                              => 'Ähnliche Produkte',
     'SHOP_MODULE_ffPushedProducts'                               => 'Pushed products',
+    'SHOP_MODULE_ffDisableCache'                                 => 'Disable cache',
     'SHOP_MODULE_GROUP_ffFeed'                                   => 'Feed-Einstellungen',
     'SHOP_MODULE_ffExportAttributes'                             => 'Exportierte Attribute',
     'HELP_SHOP_MODULE_ffExportAttributes'                        => 'Wähle die Attribute aus, die du exportieren möchtest. Multi-Attribute werden in einer Spalte gruppiert, und stellen typischerweise Filter dar.',

--- a/src/views/admin/en/ffwebcomponents_lang.php
+++ b/src/views/admin/en/ffwebcomponents_lang.php
@@ -41,6 +41,7 @@ $aLang = [
     'SHOP_MODULE_ffRecommendations'                              => 'Recommendations',
     'SHOP_MODULE_ffSimilarProducts'                              => 'Similar products',
     'SHOP_MODULE_ffPushedProducts'                               => 'Pushed products',
+    'SHOP_MODULE_ffDisableCache'                                 => 'Disable cache',
     'SHOP_MODULE_GROUP_ffFeed'                                   => 'Feed settings',
     'SHOP_MODULE_ffExportAttributes'                             => 'Exported Attributes',
     'HELP_SHOP_MODULE_ffExportAttributes'                        => 'Select attributes which you want to export. Multi-Attribute set to `No` means that specific attribute will be exported in separate column.',

--- a/tests/Unit/Export/SuggestCategoryFeed/GenerateTest.php
+++ b/tests/Unit/Export/SuggestCategoryFeed/GenerateTest.php
@@ -28,6 +28,6 @@ class GenerateTest extends TestCase
         $feed->generate($this->stream);
 
         // Then
-        $this->assertEquals("Id;Name;CategoryPath;sourceField;ParentCategory;Deeplink\n", $this->stream->getOutput()[0]);
+        $this->assertEquals("Id;Name;CategoryPath;SourceField;ParentCategory;Deeplink\n", $this->stream->getOutput()[0]);
     }
 }


### PR DESCRIPTION
 - Fixes:
   - FFWEB-2701
 - Description:
   - Add disable-cache param in shop configuration and ff-communication
 - Tested with Oxid EShop editions/versions:
   - 6.4 CE
 - Tested with PHP versions:
   - 7.4 
   - 8.1
