### PR TITLE
FFWEB-3203: Update SDK's doc requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## Unreleased
+### Change
+- Update SDK documentation
+
 ## [v5.0.0] - 2024.01.11
 ### BREAKING
 - IMPORTANT! Drop Oxid 6.x compatibility

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ customise them.
 - [License](#license)
 
 ## Requirements
-- OXID eShop 7.x
+- OXID eShop 7.0
 - PHP version 8.0 or higher
 
 **Note:** For Oxid eShop 6.x and PHP 7, please use SDK version 4.x


### PR DESCRIPTION
- Fixes: FFWEB-3203
- Description: Update SDK's doc requirements
- Tested with Oxid EShop editions/versions: 7.0
- Tested with PHP versions: 8.1

