### PR TITLE
FFWEB-3180: Add support for Oxid v7.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: ['8.1']
+        php: ['8.1', '8.2']
         deps: ['stable']
 
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 composer.lock
 /vendor
 /tmp_data
+/views/converted_frontend/

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -16,28 +16,33 @@ return $config
     ->setHideProgress(true)
     ->setUsingCache(false)
     ->setRules([
-                   '@PSR2'                        => true,
-                   '@PSR12'                       => true,
-                   'array_syntax'                 => ['syntax' => 'short'],
-                   'binary_operator_spaces'       => [
-                       'operators' => [
-                           '='  => 'align',
-                           '=>' => 'align',
-                       ]
-                   ],
-                   'blank_line_after_opening_tag' => true,
-                   'class_attributes_separation'  => true,
-                   'blank_line_before_statement'  => ['statements' => ['break', 'continue', 'declare', 'throw', 'try']],
-                   'concat_space'                 => ['spacing' => 'one'],
-                   'declare_strict_types'         => true,
-                   'increment_style'              => ['style' => 'post'],
-                   'no_superfluous_phpdoc_tags'   => false,
-                   'no_useless_else'              => true,
-                   'no_useless_return'            => true,
-                   'ordered_class_elements'       => true,
-                   'ordered_imports'              => ['imports_order' => ['class', 'function', 'const']],
-                   'strict_comparison'            => true,
-                   'yoda_style'                   => ['equal' => false, 'identical' => false, 'less_and_greater' => false],
-               ])
+        '@PSR2'                        => true,
+        '@PSR12'                       => true,
+        '@PHP74Migration:risky'        => true,
+        '@Symfony'                     => true,
+        'array_syntax'                 => ['syntax' => 'short'],
+        'binary_operator_spaces'       => [
+            'operators' => [
+                '='  => 'align',
+                '=>' => 'align',
+            ],
+        ],
+        'blank_line_after_opening_tag'                     => true,
+        'line_ending'                                      => true,
+        'class_attributes_separation'                      => false,
+        'blank_line_before_statement'                      => ['statements' => ['break', 'continue', 'declare', 'throw', 'try']],
+        'concat_space'                                     => ['spacing' => 'one'],
+        'declare_strict_types'                             => true,
+        'increment_style'                                  => ['style' => 'post'],
+        'no_superfluous_phpdoc_tags'                       => false,
+        'no_useless_else'                                  => true,
+        'no_useless_return'                                => true,
+        'ordered_class_elements'                           => true,
+        'ordered_imports'                                  => ['imports_order' => ['class', 'function', 'const']],
+        'global_namespace_import'                          => ['import_classes' => true, 'import_constants' => true, 'import_functions' => true],
+        'strict_comparison'                                => true,
+        'yoda_style'                                       => ['equal' => false, 'identical' => false, 'less_and_greater' => false],
+        'nullable_type_declaration_for_default_null_value' => false,
+    ])
     ->setFinder($finder);
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 ## Unreleased
 ### Change
 - Update SDK documentation
+- Add support for Oxid 7.1
+- Add support for PHP 8.2
+- Update composer libraries
+- Improve code style
 
 ## [v5.0.0] - 2024.01.11
 ### BREAKING

--- a/composer.json
+++ b/composer.json
@@ -14,15 +14,15 @@
     "php": "^8.1",
     "ext-ftp": "*",
     "ext-json": "*",
-    "omikron/factfinder-communication-sdk": "^0.9.7",
-    "league/flysystem-sftp": "^2.2",
-    "league/flysystem-ftp": "^2.3",
-    "monolog/monolog": "^1.23"
+    "omikron/factfinder-communication-sdk": "^0.9.9",
+    "league/flysystem-sftp": "^3.0",
+    "league/flysystem-ftp": "^3.0",
+    "monolog/monolog": "^3.0"
   },
   "require-dev": {
     "squizlabs/php_codesniffer": "^3.4",
     "friendsofphp/php-cs-fixer": "^3.22",
-    "phpmd/phpmd": "^2.9",
+    "phpmd/phpmd": "^2.15",
     "phpunit/phpunit": "^9.5"
   },
   "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "omikron/factfinder-communication-sdk": "^0.9.9",
     "league/flysystem-sftp": "^3.0",
     "league/flysystem-ftp": "^3.0",
-    "monolog/monolog": "^3.0"
+    "monolog/monolog": "^1.23"
   },
   "require-dev": {
     "squizlabs/php_codesniffer": "^3.4",

--- a/src/Component/Widget/WebComponent.php
+++ b/src/Component/Widget/WebComponent.php
@@ -20,9 +20,7 @@ class WebComponent extends WidgetController
 
     public function getCommunicationParams(): array
     {
-        $params = array_filter($this->config->getParameters(), function (string $name) {
-            return !in_array($name, ['user-id', 'search-immediate']);
-        }, ARRAY_FILTER_USE_KEY);
+        $params = array_filter($this->config->getParameters(), fn (string $name) => !in_array($name, ['user-id', 'search-immediate']), ARRAY_FILTER_USE_KEY);
 
         return $params;
     }

--- a/src/Controller/Admin/ArticleFeedController.php
+++ b/src/Controller/Admin/ArticleFeedController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Omikron\FactFinder\Oxid\Controller\Admin;
 
+use Exception;
 use Omikron\FactFinder\Oxid\Export\ArticleFeed;
 use Omikron\FactFinder\Oxid\Export\Stream\Csv;
 use Omikron\FactFinder\Oxid\Model\Api\PushImport;
@@ -36,7 +37,7 @@ class ArticleFeedController extends AdminController
             $pushImport->execute();
             $result[] = $this->translate('FF_ARTICLE_FEED_IMPORT_TRIGGERED');
             $this->addTplParam('success', true);
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             $result[] = $e->getMessage();
         }
 

--- a/src/Controller/Admin/ModuleConfiguration.php
+++ b/src/Controller/Admin/ModuleConfiguration.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Omikron\FactFinder\Oxid\Controller\Admin;
 
+use Exception;
 use Omikron\FactFinder\Communication\Client\ClientBuilder;
 use Omikron\FactFinder\Communication\Credentials;
 use Omikron\FactFinder\Communication\Resource\AdapterFactory;
@@ -44,13 +45,13 @@ class ModuleConfiguration extends ModuleConfiguration_parent
         return $template;
     }
 
-    public function saveConfVars()
+    public function saveConfVars(): void
     {
         try {
             $this->preparePostData();
             parent::saveConfVars();
             $this->addTplSuccessMessage('Module configuration was saved successfully');
-        } catch (\Exception $exception) {
+        } catch (Exception $exception) {
             $this->addTplErrorMessage($exception->getMessage());
         }
     }
@@ -80,7 +81,7 @@ class ModuleConfiguration extends ModuleConfiguration_parent
             $this->preparePostData();
             parent::saveConfVars();
             $this->addTplSuccessMessage('Field roles was updated successfully');
-        } catch (\Exception $exception) {
+        } catch (Exception $exception) {
             $this->addTplErrorMessage($exception->getMessage());
         }
     }
@@ -116,9 +117,7 @@ class ModuleConfiguration extends ModuleConfiguration_parent
     private function preparePostData(): void
     {
         if ($this->isFactFinder()) {
-            $_POST['confaarrs'] = array_reduce($this->localizedFields, function (array $result, string $field): array {
-                return [$field => $this->aarrayToMultiline($result[$field] ?? [])] + $result;
-            }, $_POST['confaarrs'] ?? []);
+            $_POST['confaarrs'] = array_reduce($this->localizedFields, fn (array $result, string $field): array => [$field => $this->aarrayToMultiline($result[$field] ?? [])] + $result, $_POST['confaarrs'] ?? []);
 
             $_POST['confaarrs']['ffExportAttributes'] = $this->aarrayToMultiline(
                 $this->flatMap(
@@ -132,9 +131,7 @@ class ModuleConfiguration extends ModuleConfiguration_parent
     private function getAvailableAttributes(): array
     {
         $attributeList = oxNew(AttributeList::class)->getList()->getArray();
-        return array_reduce($attributeList, function (array $attributes, Attribute $attribute): array {
-            return $attributes + [$attribute->getFieldData('oxid') => $attribute->oxattribute__oxtitle->rawValue];
-        }, []);
+        return array_reduce($attributeList, fn (array $attributes, Attribute $attribute): array => $attributes + [$attribute->getFieldData('oxid') => $attribute->oxattribute__oxtitle->rawValue], []);
     }
 
     private function getSelectedAttributes(array $allAttributes): array
@@ -152,9 +149,7 @@ class ModuleConfiguration extends ModuleConfiguration_parent
 
     private function prepareAttributes(): callable
     {
-        return function (array $attributeData): array {
-            return [$attributeData['id'] => $attributeData['multi']];
-        };
+        return fn (array $attributeData): array => [$attributeData['id'] => $attributeData['multi']];
     }
 
     private function flatMap(callable $fnc, array $arr): array

--- a/src/Controller/Admin/TestConnectionController.php
+++ b/src/Controller/Admin/TestConnectionController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Omikron\FactFinder\Oxid\Controller\Admin;
 
+use Exception;
 use Omikron\FactFinder\Communication\Client\ClientBuilder;
 use Omikron\FactFinder\Communication\Credentials;
 use Omikron\FactFinder\Communication\Resource\AdapterFactory;
@@ -61,7 +62,7 @@ class TestConnectionController extends AdminController
             $ftpUploader->upload(tmpfile(), 'testconnection');
             $this->success = true;
             $this->result  = Registry::getLang()->translateString('FF_TEST_CONNECTION_SUCCESS', null, true);
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             $this->result = $e->getMessage();
         }
     }

--- a/src/Controller/ArticleFeedController.php
+++ b/src/Controller/ArticleFeedController.php
@@ -14,7 +14,7 @@ class ArticleFeedController extends FrontendController
 {
     protected $exportedType = ArticleFeed::class;
 
-    public function init()
+    public function init(): void
     {
         /** @var Authentication $auth */
         $auth = oxNew(Authentication::class);

--- a/src/Controller/SearchResultController.php
+++ b/src/Controller/SearchResultController.php
@@ -71,7 +71,7 @@ class SearchResultController extends FrontendController
 
     protected function fallback(): void
     {
-        //this function could be used to implement fallback logic in case of any communication error.
+        // this function could be used to implement fallback logic in case of any communication error.
         $this->showJsonAndExit('');
     }
 

--- a/src/Core/ViewConfig.php
+++ b/src/Core/ViewConfig.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Omikron\FactFinder\Oxid\Core;
 
 use Omikron\FactFinder\Oxid\Component\Widget\WebComponent;
-use OxidEsales\Eshop\Core\Registry;
 use OxidEsales\EshopCommunity\Internal\Container\ContainerFactory;
 use OxidEsales\EshopCommunity\Internal\Framework\Module\Facade\ModuleSettingServiceInterface;
 

--- a/src/Exception/ResponseException.php
+++ b/src/Exception/ResponseException.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace Omikron\FactFinder\Oxid\Exception;
 
-class ResponseException extends \RuntimeException
+use RuntimeException;
+
+class ResponseException extends RuntimeException
 {
     public function __construct($message, $code = 0, $previous = null) // phpcs:ignore
     {
-        parent::__construct(($message ?: 'Response body was empty'), $code, $previous);
+        parent::__construct($message ?: 'Response body was empty', $code, $previous);
     }
 }

--- a/src/Export/ArticleFeed.php
+++ b/src/Export/ArticleFeed.php
@@ -58,9 +58,7 @@ class ArticleFeed extends AbstractFeed
 
     protected function getConfigFields(): array
     {
-        return array_map(function (string $attribute): FieldInterface {
-            return oxNew(AttributeField::class, $attribute);
-        }, array_values(oxNew(ExportConfig::class)->getSingleFields()));
+        return array_map(fn (string $attribute): FieldInterface => oxNew(AttributeField::class, $attribute), array_values(oxNew(ExportConfig::class)->getSingleFields()));
     }
 
     protected function getFieldName(FieldInterface $field): string

--- a/src/Export/Data/ArticleCollection.php
+++ b/src/Export/Data/ArticleCollection.php
@@ -4,12 +4,13 @@ declare(strict_types=1);
 
 namespace Omikron\FactFinder\Oxid\Export\Data;
 
+use IteratorAggregate;
 use Omikron\FactFinder\Oxid\Export\Entity\ArticleEntity;
 use OxidEsales\Eshop\Application\Model\Article;
 use OxidEsales\Eshop\Application\Model\ArticleList;
 use OxidEsales\Eshop\Core\Model\ListModel;
 
-class ArticleCollection implements \IteratorAggregate, CollectionInterface
+class ArticleCollection implements IteratorAggregate, CollectionInterface
 {
     public function __construct(private readonly int $batchSize = 100)
     {

--- a/src/Export/Data/CategoryCollection.php
+++ b/src/Export/Data/CategoryCollection.php
@@ -4,12 +4,13 @@ declare(strict_types=1);
 
 namespace Omikron\FactFinder\Oxid\Export\Data;
 
+use IteratorAggregate;
 use Omikron\FactFinder\Oxid\Export\Entity\CategoryEntity;
 use OxidEsales\Eshop\Application\Model\Category;
 use OxidEsales\Eshop\Application\Model\CategoryList;
 use OxidEsales\Eshop\Core\Model\ListModel;
 
-class CategoryCollection implements \IteratorAggregate, CollectionInterface
+class CategoryCollection implements IteratorAggregate, CollectionInterface
 {
     public function __construct(private readonly int $batchSize = 100)
     {

--- a/src/Export/Entity/ArticleEntity.php
+++ b/src/Export/Entity/ArticleEntity.php
@@ -12,7 +12,7 @@ class ArticleEntity implements ExportEntityInterface, DataProviderInterface
     public function __construct(
         protected readonly Article $article,
         protected readonly Article $parent,
-        protected readonly array $fields = []
+        protected readonly array $fields = [],
     ) {
     }
 
@@ -29,9 +29,7 @@ class ArticleEntity implements ExportEntityInterface, DataProviderInterface
             'ImageUrl'      => $this->getPictureUrl(),
         ];
 
-        return array_reduce($this->fields, function (array $result, FieldInterface $field): array {
-            return [$field->getName() => $field->getValue($this->article, $this->parent)] + $result;
-        }, $data);
+        return array_reduce($this->fields, fn (array $result, FieldInterface $field): array => [$field->getName() => $field->getValue($this->article, $this->parent)] + $result, $data);
     }
 
     public function getEntities(): iterable

--- a/src/Export/Entity/CategoryEntity.php
+++ b/src/Export/Entity/CategoryEntity.php
@@ -12,7 +12,7 @@ class CategoryEntity implements DataProviderInterface, ExportEntityInterface
     public function __construct(
         protected readonly Category $category,
         protected readonly Category $parent,
-        protected readonly array $fields
+        protected readonly array $fields,
     ) {
     }
 
@@ -38,8 +38,6 @@ class CategoryEntity implements DataProviderInterface, ExportEntityInterface
             'LongDescription' => $this->category->getFieldData('oxlongdesc'),
         ];
 
-        return array_reduce($this->fields, function (array $result, FieldInterface $field): array {
-            return [$field->getName() => $field->getValue($this->category, $this->parent)] + $result;
-        }, $data);
+        return array_reduce($this->fields, fn (array $result, FieldInterface $field): array => [$field->getName() => $field->getValue($this->category, $this->parent)] + $result, $data);
     }
 }

--- a/src/Export/Exporter.php
+++ b/src/Export/Exporter.php
@@ -10,6 +10,7 @@ use Omikron\FactFinder\Oxid\Export\Filter\TextFilter;
 use Omikron\FactFinder\Oxid\Export\Stream\StreamInterface;
 use Omikron\FactFinder\Oxid\Utilities\FfLogger;
 use OxidEsales\Eshop\Core\Registry;
+use Throwable;
 
 class Exporter implements ExporterInterface
 {
@@ -37,13 +38,13 @@ class Exporter implements ExporterInterface
             try {
                 $entityData = array_merge($emptyRecord, array_intersect_key($entity->toArray(), $emptyRecord)); // phpcs:ignore
                 $stream->addEntity($this->prepare($entityData));
-            } catch (\Throwable $e) {
+            } catch (Throwable $e) {
                 $this->handleError($e, $entity);
             }
         }
     }
 
-    private function handleError(\Throwable $exception, ExportEntityInterface $entity): void
+    private function handleError(Throwable $exception, ExportEntityInterface $entity): void
     {
         if ($this->proceedWhileError === false) {
             throw $exception;

--- a/src/Export/Field/Attribute.php
+++ b/src/Export/Field/Attribute.php
@@ -29,9 +29,7 @@ class Attribute implements FieldInterface
     {
         $attributes = $this->getAttributes($article->getId(), $article->getParentId());
 
-        return array_reduce($attributes, function (array $result, array $attribute) {
-            return $result + [$attribute['OXTITLE'] => $attribute['OXVALUE']];
-        }, []);
+        return array_reduce($attributes, fn (array $result, array $attribute) => $result + [$attribute['OXTITLE'] => $attribute['OXVALUE']], []);
     }
 
     protected function getAttributes($articleId, $parentId): array
@@ -62,8 +60,6 @@ class Attribute implements FieldInterface
             return $articleAttributes;
         }
 
-        return array_values(array_reduce($articleAttributes + $parentAttributes, function (array $added, array $attribute): array {
-            return in_array($attribute['OXID'], $added) ? $added : $added + [$attribute['OXID'] => $attribute];
-        }, []));
+        return array_values(array_reduce($articleAttributes + $parentAttributes, fn (array $added, array $attribute): array => in_array($attribute['OXID'], $added) ? $added : $added + [$attribute['OXID'] => $attribute], []));
     }
 }

--- a/src/Export/Field/Category/CategoryPath.php
+++ b/src/Export/Field/Category/CategoryPath.php
@@ -27,7 +27,7 @@ class CategoryPath implements FieldInterface
     protected function getPath(Category $category, string $glue = '/'): string
     {
         $path = [
-            rawurlencode($this->filter->filterValue($category->getTitle()))
+            rawurlencode($this->filter->filterValue($category->getTitle())),
         ];
 
         while ($category->isTopCategory() === false) {

--- a/src/Export/Field/FilterAttributes.php
+++ b/src/Export/Field/FilterAttributes.php
@@ -38,20 +38,14 @@ class FilterAttributes extends Attribute implements FieldInterface
         $oxvarname   = $parent->getFieldData('oxvarname');
         $oxvarselect = $article->getFieldData('oxvarselect');
 
-        return implode('', array_map(function (string $key, ?string $value): string {
-            return $this->filter->filterValue($key) . '=' . $this->filter->filterValue($value) . '|';
-        }, ...array_map(function (?string $value): array {
-            return explode(' | ', $value);
-        }, [$this->validateValueForExport($oxvarname), $this->validateValueForExport($oxvarselect)])));
+        return implode('', array_map(fn (string $key, ?string $value): string => $this->filter->filterValue($key) . '=' . $this->filter->filterValue($value) . '|', ...array_map(fn (?string $value): array => explode(' | ', $value), [$this->validateValueForExport($oxvarname), $this->validateValueForExport($oxvarselect)])));
     }
 
     protected function getAllValues(Article $article): string
     {
         $variants = $article->getVariantSelections()['selections'] ?? [];
         return array_reduce($variants, function (string $result, VariantSelectList $variant): string {
-            $values = array_map(function (Selection $selection): string {
-                return $this->filter->filterValue($selection->getName());
-            }, $variant->getSelections());
+            $values = array_map(fn (Selection $selection): string => $this->filter->filterValue($selection->getName()), $variant->getSelections());
             return $result . $this->filter->filterValue($variant->getLabel()) . '=' . implode('#', $values) . '|';
         }, '');
     }

--- a/src/Model/Api/PushImport.php
+++ b/src/Model/Api/PushImport.php
@@ -53,11 +53,7 @@ class PushImport
 
     protected function getPushImportTypes(string $version): array
     {
-        return array_map(function (string $type) use ($version): string {
-            return $version === 'ng' && $type === 'data' ? 'search' : $type;
-        }, array_filter(['data', 'suggest', 'recommendation'], function (string $type): bool {
-            return (bool) $this->moduleSettingService->getBoolean(sprintf('ffAutomaticImport%s', ucfirst($type)), 'ffwebcomponents');
-        }));
+        return array_map(fn (string $type): string => $version === 'ng' && $type === 'data' ? 'search' : $type, array_filter(['data', 'suggest', 'recommendation'], fn (string $type): bool => (bool) $this->moduleSettingService->getBoolean(sprintf('ffAutomaticImport%s', ucfirst($type)), 'ffwebcomponents')));
     }
 
     protected function getChannel(string $lang): string

--- a/src/Model/Config/Communication.php
+++ b/src/Model/Config/Communication.php
@@ -6,7 +6,6 @@ namespace Omikron\FactFinder\Oxid\Model\Config;
 
 use Omikron\FactFinder\Oxid\Contract\Config\ParametersSourceInterface;
 use Omikron\FactFinder\Oxid\Export\Filter\TextFilter;
-use OxidEsales\Eshop\Application\Controller\FrontendController;
 use OxidEsales\Eshop\Application\Model\Category;
 use OxidEsales\Eshop\Core\Controller\BaseController;
 use OxidEsales\Eshop\Core\Registry;
@@ -140,9 +139,7 @@ class Communication implements ParametersSourceInterface
 
     protected function mergeParameters(array $baseParams, array $additionalParams): array
     {
-        return array_reduce($this->mergeableParams, function (array $result, string $param) use ($additionalParams) {
-            return [$param => implode(',', array_column([$additionalParams, $result], $param))] + $result;
-        }, $baseParams);
+        return array_reduce($this->mergeableParams, fn (array $result, string $param) => [$param => implode(',', array_column([$additionalParams, $result], $param))] + $result, $baseParams);
     }
 
     protected function getChannel(string $langAbbr): string
@@ -163,9 +160,7 @@ class Communication implements ParametersSourceInterface
 
     private function ngPath(array $categories, string $param): string
     {
-        $categoryPath = array_map(function ($category) {
-            return (string) $this->encodeCategoryName(trim($category));
-        }, array_reverse($categories));
+        $categoryPath = array_map(fn ($category) => (string) $this->encodeCategoryName(trim($category)), array_reverse($categories));
 
         return sprintf('filter=%s', urlencode($param . ':' . implode('/', $categoryPath)));
     }
@@ -185,7 +180,7 @@ class Communication implements ParametersSourceInterface
 
     private function encodeCategoryName(string $path): string
     {
-        //important! do not modify this code
+        // important! do not modify this code
         return preg_replace(
             '/\+/',
             '%2B',

--- a/src/Model/Config/Export.php
+++ b/src/Model/Config/Export.php
@@ -6,7 +6,6 @@ namespace Omikron\FactFinder\Oxid\Model\Config;
 
 use OxidEsales\Eshop\Application\Model\AttributeList;
 use OxidEsales\Eshop\Core\Model\BaseModel;
-use OxidEsales\Eshop\Core\Registry;
 use OxidEsales\EshopCommunity\Internal\Container\ContainerFactory;
 use OxidEsales\EshopCommunity\Internal\Framework\Module\Facade\ModuleSettingServiceInterface;
 
@@ -24,9 +23,7 @@ class Export
 
     public function getSingleFields(): array
     {
-        return array_intersect_key($this->getAttributes(), array_filter($this->getConfigValue(), function ($value) {
-            return !$value;
-        }));
+        return array_intersect_key($this->getAttributes(), array_filter($this->getConfigValue(), fn ($value) => !$value));
     }
 
     public function getConfigValue(): array
@@ -42,8 +39,6 @@ class Export
     {
         $this->attributes = $this->attributes ?? oxNew(AttributeList::class)->getList()->getArray();
 
-        return array_map(function (BaseModel $attribute): string {
-            return $attribute->oxattribute__oxtitle->rawValue;
-        }, $this->attributes);
+        return array_map(fn (BaseModel $attribute): string => $attribute->oxattribute__oxtitle->rawValue, $this->attributes);
     }
 }

--- a/src/Model/Config/FieldRolesMapper.php
+++ b/src/Model/Config/FieldRolesMapper.php
@@ -27,8 +27,6 @@ class FieldRolesMapper
 
     private function getOrEmptyString(array $fieldRoles): callable
     {
-        return function (string $key) use ($fieldRoles) {
-            return $fieldRoles[$key] ?? '';
-        };
+        return fn (string $key) => $fieldRoles[$key] ?? '';
     }
 }

--- a/src/Model/Config/FtpParams.php
+++ b/src/Model/Config/FtpParams.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Omikron\FactFinder\Oxid\Model\Config;
 
-use OxidEsales\Eshop\Core\Config;
-use OxidEsales\Eshop\Core\Registry;
 use OxidEsales\EshopCommunity\Internal\Container\ContainerFactory;
 use OxidEsales\EshopCommunity\Internal\Framework\Module\Facade\ModuleSettingService;
 use OxidEsales\EshopCommunity\Internal\Framework\Module\Facade\ModuleSettingServiceInterface;

--- a/src/Model/Export/Http/Authentication.php
+++ b/src/Model/Export/Http/Authentication.php
@@ -69,7 +69,7 @@ class Authentication
     /**
      * Set "auth failed" headers and returns to browser.
      */
-    public function setAuthenticationFailed(string $realm = 'FACT-Finder')
+    public function setAuthenticationFailed(string $realm = 'FACT-Finder'): void
     {
         $this->utils->setHeader('HTTP/1.1 401 Unauthorized');
         $this->utils->setHeader('WWW-Authenticate: Basic realm="' . $realm . '"');

--- a/src/Model/Export/SftpClient.php
+++ b/src/Model/Export/SftpClient.php
@@ -20,7 +20,7 @@ class SftpClient implements UploadInterface
         );
     }
 
-    public function upload($handle, string $filename)
+    public function upload($handle, string $filename): void
     {
         $this->connection->writeStream($filename, $handle);
     }

--- a/src/Subscriber/AfterRequestProcessedEventSubscriber.php
+++ b/src/Subscriber/AfterRequestProcessedEventSubscriber.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Omikron\FactFinder\Oxid\Subscriber;
 
-use OxidEsales\Eshop\Core\Config;
 use OxidEsales\Eshop\Core\Registry;
 use OxidEsales\Eshop\Core\Request;
 use OxidEsales\Eshop\Core\Session;

--- a/src/Subscriber/BeforeHeadersSendEventSubscriber.php
+++ b/src/Subscriber/BeforeHeadersSendEventSubscriber.php
@@ -6,7 +6,6 @@ namespace Omikron\FactFinder\Oxid\Subscriber;
 
 use DateTime;
 use Exception;
-use OxidEsales\Eshop\Core\Config;
 use OxidEsales\Eshop\Core\Registry;
 use OxidEsales\Eshop\Core\Session;
 use OxidEsales\EshopCommunity\Internal\Container\ContainerFactory;

--- a/src/Twig/Extensions/Filters/RecordDataJson.php
+++ b/src/Twig/Extensions/Filters/RecordDataJson.php
@@ -56,7 +56,7 @@ class RecordDataJson extends AbstractExtension
             [
                 'idType'        => 'productNumber',
                 'productNumber' => $recordId,
-                'format'        => 'json'
+                'format'        => 'json',
             ]
         );
 


### PR DESCRIPTION
- Fixes FFWEB-3180
- Description: 
    - Add support for Oxid 7.1
    - Add support for PHP 8.2
    - Update composer libraries
    - Improve code style
- Tested with Oxid EShop editions/versions: 7.1
- Tested with PHP versions: 8.2

