### PR TITLE
FFWEB-3183: Rewrite SDK configuration page

### DIFF
--- a/metadata.php
+++ b/metadata.php
@@ -21,7 +21,7 @@ $aModule = [
     'author'      => "{$moduleName} Team",
     'url'         => 'https://web-components.fact-finder.de',
     'description' => "{$moduleName} integration for OXID eShop by {$companyName}",
-    'version'     => '5.0.0',
+    'version'     => '6.0.0',
     'thumbnail'   => 'pictures/logo.png',
     'controllers' => [
         'ffWebComponent'             => Component\Widget\WebComponent::class,
@@ -72,6 +72,13 @@ $aModule = [
             'group'    => 'ffMain',
             'name'     => 'ffPublicPassword',
             'type'     => 'str',
+            'position' => $settingPosition++,
+        ],
+        [
+            'group'    => 'ffMain',
+            'name'     => 'ffApiKey',
+            'type'     => 'str',
+            'value'    => 'YOUR_API_KEY',
             'position' => $settingPosition++,
         ],
         [

--- a/views/admin_twig/de/ffwebcomponents_de_lang.php
+++ b/views/admin_twig/de/ffwebcomponents_de_lang.php
@@ -11,6 +11,7 @@ $aLang = [
     'SHOP_MODULE_ffPassword'                                     => 'Passwort for the FACT-Finder Import User',
     'SHOP_MODULE_ffPublicUsername'                               => 'Username for fetching data from FACT-Finder',
     'SHOP_MODULE_ffPublicPassword'                               => 'Password for fetching data from FACT-Finder',
+    'SHOP_MODULE_ffApiKey'                                       => 'FACT-Finder API key',
     'SHOP_MODULE_ffAuthPrefix'                                   => 'Authorisierungs-Präfix',
     'SHOP_MODULE_ffAuthPostfix'                                  => 'Authorisierungs-Postfix',
     'SHOP_MODULE_GROUP_ffAdvanced'                               => 'Erweiterte Einstellungen',

--- a/views/admin_twig/en/ffwebcomponents_en_lang.php
+++ b/views/admin_twig/en/ffwebcomponents_en_lang.php
@@ -11,6 +11,7 @@ $aLang = [
     'SHOP_MODULE_ffPassword'                                     => 'Password for the FACT-Finder Import User',
     'SHOP_MODULE_ffPublicUsername'                               => 'Username for fetching data from FACT-Finder',
     'SHOP_MODULE_ffPublicPassword'                               => 'Password for fetching data from FACT-Finder',
+    'SHOP_MODULE_ffApiKey'                                       => 'FACT-Finder API key',
     'SHOP_MODULE_ffAuthPrefix'                                   => 'Authorization Prefix',
     'SHOP_MODULE_ffAuthPostfix'                                  => 'Authorization Postfix',
     'SHOP_MODULE_GROUP_ffAdvanced'                               => 'Advanced',


### PR DESCRIPTION
- Fixes FFWEB-3183
- Description: Rewrite SDK configuration page
- Tested with Oxid EShop editions/versions: 7.1
- Tested with PHP versions: 8.2

