### PR TITLE
FFWEB-3248: Add test push import connection buttons

### DIFF
--- a/src/Controller/Admin/TestConnectionController.php
+++ b/src/Controller/Admin/TestConnectionController.php
@@ -8,6 +8,7 @@ use Exception;
 use Omikron\FactFinder\Communication\Client\ClientBuilder;
 use Omikron\FactFinder\Communication\Credentials;
 use Omikron\FactFinder\Communication\Resource\AdapterFactory;
+use Omikron\FactFinder\Communication\Version;
 use Omikron\FactFinder\Oxid\Model\Export\UploadFactory;
 use OxidEsales\Eshop\Application\Controller\Admin\AdminController;
 use OxidEsales\Eshop\Core\Registry;
@@ -32,12 +33,34 @@ class TestConnectionController extends AdminController
         try {
             $clientBuilder = oxNew(ClientBuilder::class)
                 ->withServerUrl($this->param('serverUrl'))
-                ->withApiKey($this->getConfigParam('ffApiKey'));
+                ->withApiKey($this->param('apiKey'));
 
             $adapterFactory = new AdapterFactory(
                 $clientBuilder,
-                $this->param('version'),
-                $this->param('apiVersion')
+                Version::NG,
+                'v5'
+            );
+            $searchAdapter = $adapterFactory->getSearchAdapter();
+            $searchAdapter->search($this->param('channel'), 'FACT-Finder version');
+
+            $this->success = true;
+            $this->result  = Registry::getLang()->translateString('FF_TEST_CONNECTION_SUCCESS', null, true);
+        } catch (ClientExceptionInterface $e) {
+            $this->result = $e->getMessage();
+        }
+    }
+
+    public function testPushImport(): void
+    {
+        try {
+            $clientBuilder = oxNew(ClientBuilder::class)
+                ->withServerUrl($this->param('serverUrl'))
+                ->withCredentials($this->getCredentials());
+
+            $adapterFactory = new AdapterFactory(
+                $clientBuilder,
+                Version::NG,
+                'v5'
             );
             $searchAdapter = $adapterFactory->getSearchAdapter();
             $searchAdapter->search($this->param('channel'), 'FACT-Finder version');
@@ -78,7 +101,7 @@ class TestConnectionController extends AdminController
 
     protected function getCredentials(): Credentials
     {
-        return new Credentials(...array_map([$this, 'param'], ['username', 'password', 'prefix', 'postfix']));
+        return new Credentials(...array_map([$this, 'param'], ['username', 'password']));
     }
 
     protected function param(string $key): string

--- a/views/twig/extensions/themes/admin_twig/module_config.html.twig
+++ b/views/twig/extensions/themes/admin_twig/module_config.html.twig
@@ -32,6 +32,13 @@
                name="ffTestFtpConnection"
                value="Test FTP Connection"
                onclick="testFtpConnection()"/>
+
+        <input type="button"
+               id="ffTestPushImport"
+               class="confinput"
+               name="ffTestPushImport"
+               value="Test Push Import"
+               onclick="testPushImport()"/>
         <div id="spinner">
         </div>
         <div id="result">
@@ -44,6 +51,26 @@
                     type:     'POST',
                     dataType: 'json',
                     data: getTestConnectionParams(),
+                    beforeSend: function() {
+                        jQuery('#spinner').addClass('loading');
+                    },
+                    complete: function (response) {
+                        setTimeout(
+                            function () {
+                                jQuery('#spinner').removeClass('loading');
+                                jQuery('#result').html(response.responseText);
+                            }, 1000
+                        )
+                    }
+                });
+            }
+
+            function testPushImport() {
+                jQuery.ajax({
+                    url:      'index.php?cl=test_connection&fnc=testPushImport&stoken=' + jQuery('input[name="stoken"]').val(),
+                    type:     'POST',
+                    dataType: 'json',
+                    data: getTestPushImportParams(),
                     beforeSend: function() {
                         jQuery('#spinner').addClass('loading');
                     },
@@ -98,10 +125,16 @@
 
             function getTestConnectionParams() {
                 return {
+                    apiKey:     jQuery('[name="confstrs[ffApiKey]"]').val(),
+                    serverUrl:  jQuery('[name="confstrs[ffServerUrl]"]').val(),
+                    channel:    jQuery('[name="confaarrs[ffChannel][de]"]').val(),
+                }
+            }
+
+            function getTestPushImportParams() {
+                return {
                     username:   jQuery('[name="confstrs[ffUsername]"]').val(),
                     password:   jQuery('[name="confstrs[ffPassword]"]').val(),
-                    prefix:     jQuery('[name="confstrs[ffAuthPrefix]"]').val(),
-                    postfix:    jQuery('[name="confstrs[ffAuthPostfix]"]').val(),
                     serverUrl:  jQuery('[name="confstrs[ffServerUrl]"]').val(),
                     channel:    jQuery('[name="confaarrs[ffChannel][de]"]').val(),
                 }


### PR DESCRIPTION
- Fixes #FFWEB-3248
- Description: Add test push import connection buttons
- Tested with Oxid EShop editions/versions: 7.1
- Tested with PHP versions: 8.2
