### PR TITLE
FFWEB-3277: Set correct CategoryPath field name for searchParamsFromUrl

### DIFF
--- a/views/twig/extensions/themes/default/layout/base.html.twig
+++ b/views/twig/extensions/themes/default/layout/base.html.twig
@@ -88,25 +88,9 @@
             });
 
             {% if oViewConf.getSearchImmediate()|escape("js") and oView.getClassKey() == "search_result" %}
-                const searchParams = factfinder.utils.env.searchParamsFromUrl();
+                const searchParams = factfinder.utils.env.searchParamsFromUrl({ categoryFieldName: `{{oViewConf.getFFStringConfigParam('ffCategoryPathFieldName')}}` });
                 initialSearch(searchParams, { requestOptions: { origin: `initialSearch` } });
             {% endif %}
-
-            {#if ('{{ oViewConf.getSearchImmediate()|escape("js") }}') {#}
-            {#    const searchParams = factfinder.utils.env.searchParamsFromUrl();#}
-            {#    initialSearch(searchParams, { requestOptions: { origin: `initialSearch` } });#}
-            {#}#}
-
-{#            {% if page.extensions.factfinder.searchImmediate and not page.extensions.factfinder.ssr %}#}
-{#            const searchParams = factfinder.utils.env.searchParamsFromUrl();#}
-{#            initialSearch(searchParams, { requestOptions: { origin: `initialSearch` } });#}
-{#            {% endif %}#}
-
-{#            {% if page.extensions.factfinder.searchImmediate and not page.extensions.factfinder.ssr %}#}
-{#            const searchParams = factfinder.utils.env.searchParamsFromUrl();#}
-{#            initialSearch(searchParams, { requestOptions: { origin: `initialSearch` } });#}
-{#            {% endif %}#}
-
 
             {#Category Pages#}
             {% if oView.getClassKey() == "alist" %}


### PR DESCRIPTION
- Fixes # FFWEB-3277
- Description: Set correct CategoryPath field name for searchParamsFromUrl
- Tested with Oxid EShop editions/versions: 7.1
- Tested with PHP versions: 8.2

