### PR TITLE
FFWEB-3277: Fix problem with missing URL parameter

### DIFF
--- a/views/twig/extensions/themes/default/layout/base.html.twig
+++ b/views/twig/extensions/themes/default/layout/base.html.twig
@@ -37,6 +37,17 @@
                 },
             });
 
+            factfinder.routing.setUrlParamOptionsListener(() => ({
+                postStringifier: pairs => {
+                    new URLSearchParams(window.location.search).entries().forEach(([key, value]) => {
+                        if (!pairs.find(p => p.key === key)) {
+                            pairs.push({ key, value });
+                        }
+                    });
+                    return pairs;
+                },
+            }));
+
             {% if oViewConf.getFFStringConfigParam('ffParameterWhitelist') is not empty %}
               factfinder.routing.setUrlParamOptionsListener(() => ({
                 allow:


### PR DESCRIPTION
- Fixes # FFWEB-3277
- Description: Fix problem with missing ulr parameter during asn filtering
- Tested with Oxid EShop editions/versions: 7.1
- Tested with PHP versions: 8.2
