### PR TITLE
FFWEB-3298: Add support for multi-language store

### DIFF
--- a/views/twig/extensions/themes/default/layout/base.html.twig
+++ b/views/twig/extensions/themes/default/layout/base.html.twig
@@ -10,7 +10,7 @@
     <script src="{{ oViewConf.getModuleUrl("ffwebcomponents", "/js/utils.js")|escape }}"></script>
     <style>[unresolved]{opacity:0;display:none}</style>
 
-{#    {{ dump(oViewConf.getCommunicationParams()['currency-country-code']) }}#}
+{#    {{ dump(oViewConf.getCommunicationParams()['channel']) }}#}
 {#    {{ dump(oViewConf.getUrlParameters() ) }}#}
 
     <!--Main FF Web-components Initialisation -->
@@ -21,7 +21,7 @@
             init({
                 ff: {
                     url: `{{oViewConf.getFFStringConfigParam('ffServerUrl')}}`,
-                    channel: `{{oViewConf.getFFArrayConfigParam('ffChannel').en}}`,
+                    channel: `{{communicationParams['channel']}}`,
                     apiKey: `{{oViewConf.getFFStringConfigParam('ffApiKey')}}`,
                 },
                 appConfig: {


### PR DESCRIPTION
Add support for multi-language store. Be default support English and Deutsch languages

- Fixes # FFWEB-3298
- Description: Add support for multi-language store
- Tested with Oxid EShop editions/versions: 7.2
- Tested with PHP versions: 8.2

