### PR TITLE
FFWEB-3303: Set correct CLI export bootstrap file

### DIFF
--- a/src/bin/feed-upload.php
+++ b/src/bin/feed-upload.php
@@ -4,28 +4,24 @@ declare(strict_types=1);
 
 use Omikron\FactFinder\Oxid\Export\FeedTypes;
 use Omikron\FactFinder\Oxid\Model\Export\UploadFactory;
+use Omikron\FactFinder\Oxid\Export\Stream\Csv;
+use Omikron\FactFinder\Oxid\Model\Api\PushImport;
+use OxidEsales\Eshop\Core\Config;
+use OxidEsales\Eshop\Core\Registry;
 
 $options    = getopt('s:t:l:');
 $shopId     = $options['s'] ?? 0;
 $exportType = $options['t'] ?? 'product';
 
-if (!$shopId) {
+if (!$shopId && $shopId !== 0) {
     throw new RuntimeException('Please specify the shop ID using the "s" parameter!');
 }
 
 $languageId = $options['l'] ?? 0;
 
-require_once dirname(__FILE__) . '/../../../../bootstrap.php';
+require_once dirname(__FILE__) . '/../../../../../source/bootstrap.php';
 
 define('OX_IS_ADMIN', true);
-
-use Omikron\FactFinder\Oxid\Controller\ArticleFeedController;
-use Omikron\FactFinder\Oxid\Export\Stream\Csv;
-use Omikron\FactFinder\Oxid\Model\Api\PushImport;
-use Omikron\FactFinder\Oxid\Model\Config\FtpParams;
-use Omikron\FactFinder\Oxid\Model\Export\FtpClient;
-use OxidEsales\Eshop\Core\Config;
-use OxidEsales\Eshop\Core\Registry;
 
 try {
     $feedFQN = FeedTypes::getFeedType($exportType);

--- a/src/bin/feed-write.php
+++ b/src/bin/feed-write.php
@@ -3,6 +3,9 @@
 declare(strict_types=1);
 
 use Omikron\FactFinder\Oxid\Export\FeedTypes;
+use Omikron\FactFinder\Oxid\Export\Stream\Csv;
+use OxidEsales\Eshop\Core\Config;
+use OxidEsales\Eshop\Core\Registry;
 
 $options    = getopt('s:t:l:');
 $shopId     = $options['s'] ?? 0;
@@ -14,14 +17,9 @@ if (!$shopId && $shopId !== 0) {
 
 $languageId = $options['l'] ?? 0;
 
-require_once dirname(__FILE__) . '/../../../../../bootstrap.php';
+require_once dirname(__FILE__) . '/../../../../../source/bootstrap.php';
 
 define('OX_IS_ADMIN', true);
-
-use Omikron\FactFinder\Oxid\Controller\ArticleFeedController;
-use Omikron\FactFinder\Oxid\Export\Stream\Csv;
-use OxidEsales\Eshop\Core\Config;
-use OxidEsales\Eshop\Core\Registry;
 
 Registry::getConfig()->setShopId($shopId);
 Registry::set(Config::class, null);


### PR DESCRIPTION
- Fixes # FFWEB-3303
- Description:  Set correct CLI export bootstrap file
- Tested with Oxid EShop editions/versions: 7.2
- Tested with PHP versions: 8.2

